### PR TITLE
Fix incorrect notThrows → toThrowError conversion

### DIFF
--- a/src/transformers/ava.js
+++ b/src/transformers/ava.js
@@ -102,7 +102,7 @@ export default function avaToJest(fileInfo, api) {
                         );
                     } else {
                         newCondition = j.callExpression(
-                            j.identifier('toThrowError'),
+                            j.identifier(oldPropertyName === 'throws' ? 'toThrowError' : 'not.toThrowError'),
                             [args[1]]
                         );
                     }

--- a/src/transformers/ava.test.js
+++ b/src/transformers/ava.test.js
@@ -58,6 +58,7 @@ test('mapping', (t) => {
   t.throws(() => {}, 'foo');
   t.throws(afunc, 'foo');
   t.throws(afunc);
+  t.notThrows(() => {}, 'foo');
   t.notThrows(() => {});
   t.notSame(abc, {a: 'x', b: 'y', c: 'z'})
   t.notDeepEqual(abc, {a: 'x', b: 'y', c: 'z'})
@@ -84,6 +85,7 @@ it('mapping', () => {
   expect(() => {}).toThrowError('foo');
   expect(afunc).toThrowError('foo');
   expect(afunc).toThrow();
+  expect(() => {}).not.toThrowError('foo');
   expect(() => {}).not.toThrow();
   expect(abc).not.toEqual({a: 'x', b: 'y', c: 'z'})
   expect(abc).not.toEqual({a: 'x', b: 'y', c: 'z'})


### PR DESCRIPTION
```diff
- t.notThrows(() => new Function(result), SyntaxError);  // eslint-disable-line no-new-func
+ expect(() => new Function(result)).toThrowError(SyntaxError);  // eslint-disable-line no-new-func
```

Should be `not.toThrowError`.