### PR TITLE
Add Mocha Transformer

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -37,12 +37,14 @@ const cli = meow(
 
 updateNotifier({ pkg: cli.pkg }).notify({ defer: false });
 
+const allTransformers = ['tape', 'ava', 'mocha'];
+
 if (cli.input.length) {
     // Apply all transformers if input is given using CLI.
     if (!cli.flags.dry) {
         checkGitStatus(cli.flags.force);
     }
-    executeTransformations(cli.input, cli.flags, ['tape', 'ava']);
+    executeTransformations(cli.input, cli.flags, allTransformers);
 } else {
     // Else show the fancy inquirer prompt.
     inquirer.prompt([{
@@ -55,6 +57,9 @@ if (cli.input.length) {
         }, {
             name: 'AVA',
             value: 'ava',
+        }, {
+            name: 'Mocha',
+            value: 'mocha',
         }, {
             name: 'All of the above!',
             value: 'all',
@@ -72,7 +77,7 @@ if (cli.input.length) {
         const { files, transformer } = answers;
 
         if (transformer === 'other') {
-            console.log('\nCurrently jest-codemods only have support for AVA and Tape.');
+            console.log('\nCurrently jest-codemods only have support for AVA, Tape, and Mocha.');
             console.log('Feel free to create an issue on https://github.com/skovhus/jest-codemods to contribute!\n');
             return;
         }
@@ -91,7 +96,7 @@ if (cli.input.length) {
             checkGitStatus(cli.flags.force);
         }
 
-        const transformers = transformer === 'all' ? ['tape', 'ava'] : [transformer];
+        const transformers = transformer === 'all' ? allTransformers : [transformer];
         executeTransformations(filesExpanded, cli.flags, transformers);
     });
 }

--- a/src/transformers/mocha.js
+++ b/src/transformers/mocha.js
@@ -1,0 +1,50 @@
+import detectQuoteStyle from '../utils/quote-style';
+
+const methodMap = {
+    suite: 'describe',
+    context: 'describe',
+    specify: 'it',
+    test: 'it',
+    before: 'beforeAll',
+    setup: 'beforeEach',
+    after: 'afterAll',
+    teardown: 'afterEach',
+    suiteSetup: 'beforeAll',
+    suiteTeardown: 'afterAll',
+};
+
+const methodModifiers = ['only', 'skip'];
+
+export default function mochaToJest(file, api) {
+    const j = api.jscodeshift;
+    const ast = j(file.source);
+
+    Object.keys(methodMap).forEach(mochaMethod => {
+        const jestMethod = methodMap[mochaMethod];
+
+        ast.find(j.CallExpression, {
+            type: 'CallExpression',
+            callee: { type: 'Identifier', name: mochaMethod },
+        }).replaceWith(path => j.callExpression(j.identifier(jestMethod), path.value.arguments));
+
+
+        methodModifiers.forEach(modifier => {
+            ast.find(j.CallExpression, {
+                type: 'CallExpression',
+                callee: {
+                    type: 'MemberExpression',
+                    object: { type: 'Identifier', name: mochaMethod },
+                    property: { type: 'Identifier', name: modifier },
+                },
+            }).replaceWith(path => j.callExpression(j.memberExpression(
+                j.identifier(jestMethod),
+                j.identifier(modifier)
+            ), path.value.arguments));
+        });
+    });
+
+    // As Recast is not preserving original quoting, we try to detect it,
+    // and default to something sane.
+    const quote = detectQuoteStyle(j, ast) || 'single';
+    return ast.toSource({ quote });
+}

--- a/src/transformers/mocha.test.js
+++ b/src/transformers/mocha.test.js
@@ -1,0 +1,102 @@
+/* eslint-env jest */
+import { wrapPlugin } from '../utils/test-helpers';
+import plugin from './mocha';
+
+const wrappedPlugin = wrapPlugin(plugin);
+
+let consoleWarnings = [];
+beforeEach(() => {
+    consoleWarnings = [];
+    console.warn = v => consoleWarnings.push(v);
+});
+
+function testChanged(msg, source, expectedOutput) {
+    test(msg, () => {
+        const result = wrappedPlugin(source);
+        expect(result).toBe(expectedOutput);
+        expect(consoleWarnings).toEqual([]);
+    });
+}
+
+testChanged('maps BDD-style interface',
+`
+// @flow
+describe('describe', () => {
+  before(() => {});
+  after(() => {});
+  beforeEach(() => {});
+  afterEach(() => {});
+  context('context', () => {
+    it('it', () => {});
+    specify('specify', () => {})
+  })
+})
+`,
+`
+// @flow
+describe('describe', () => {
+  beforeAll(() => {});
+  afterAll(() => {});
+  beforeEach(() => {});
+  afterEach(() => {});
+  describe('context', () => {
+    it('it', () => {});
+    it('specify', () => {})
+  })
+})
+`);
+
+testChanged('maps TDD-style interface',
+`
+// @flow
+suite('suite', () => {
+  suiteSetup(() => {});
+  suiteTeardown(() => {});
+  setup(() => {});
+  teardown(() => {});
+  test(() => {});
+})
+`,
+`
+// @flow
+describe('suite', () => {
+  beforeAll(() => {});
+  afterAll(() => {});
+  beforeEach(() => {});
+  afterEach(() => {});
+  it(() => {});
+})
+`
+);
+
+testChanged('preserves exclusive tests',
+`
+// @flow
+suite.only('only suite', () => {
+  test.only('only test', () => {});
+});
+`,
+`
+// @flow
+describe.only('only suite', () => {
+  it.only('only test', () => {});
+});
+`
+);
+
+testChanged('preserves skipped tests',
+`
+// @flow
+suite.skip('skip suite', () => {
+  test.skip('skip test', () => {});
+  test('test will be skipped');
+});
+`,
+`
+// @flow
+describe.skip('skip suite', () => {
+  it.skip('skip test', () => {});
+  it('test will be skipped');
+});
+`
+);


### PR DESCRIPTION
This adds a transformer for Mocha TDD, BDD, and QUnit style interfaces. It's fairly simple and to the point.

**Issues:**
* Mocha doesn't necessarily require you to use import/require statements, just like Jest doesn't, so it's not logical to break out of the transformer with the current pattern of checking for import/require statements first.
* Mocha also has much more rarely used interfaces, "exports" and "require". Exports cannot be changed automatically with confidence, since there's no real indication that the export is a test. Require-style can be done, but I'm not certain it's very common and I was really just going for the shortest path here because... (see note below)
* Mocha doesn't have its own expectations/assertions, so this doesn't fix them. I plan on following up with separate PRs for Chai and Should.js

_Note: Trying to make there be one source of truth for converting to codemod, so I'm moving this from [my package](https://github.com/paularmstrong/mocha-to-jest-codemod)..._