### PR TITLE
Add Chai Assert Support

### DIFF
--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -315,7 +315,7 @@ export default function transformer(fileInfo, api) {
     // Object-specific boolean checks
     objectChecks.forEach(check => {
         const isNegative = check.indexOf('isNot') === 0;
-        const expectation = isNegative ? `is${check.substring(5)}` : check;
+        const expectation = check.replace('isNot', 'is');
         ast.find(j.CallExpression, getAssertionExpression(check))
             .replaceWith(path => (isNegative ? makeNegativeExpectation : makeExpectation)('toBe',
                 j.callExpression(

--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -207,11 +207,15 @@ export default function transformer(fileInfo, api) {
         }
 
         ast.find(j.CallExpression, getAssertionExpression(assert))
-            .replaceWith(path => makeExpectation(expect, ...getArguments(path, ignoreExpectedValue, override)));
+            .replaceWith(path =>
+                makeExpectation(expect, ...getArguments(path, ignoreExpectedValue, override))
+            );
 
         if (includeNegative) {
             ast.find(j.CallExpression, getAssertionExpression(includeNegative))
-                .replaceWith(path => makeNegativeExpectation(expect, ...getArguments(path, ignoreExpectedValue, override)));
+                .replaceWith(path =>
+                    makeNegativeExpectation(expect, ...getArguments(path, ignoreExpectedValue, override))
+                );
         }
     });
 
@@ -223,7 +227,10 @@ export default function transformer(fileInfo, api) {
 
     ['approximately', 'closeTo'].forEach(assertion => {
         ast.find(j.CallExpression, getAssertionExpression(assertion))
-            .replaceWith(path => makeExpectation('toBeCloseTo', path.value.arguments[0], path.value.arguments.slice(1, 3)));
+            .replaceWith(path => makeExpectation('toBeCloseTo',
+                path.value.arguments[0],
+                path.value.arguments.slice(1, 3))
+            );
     });
 
     // assert.fail -> expect(false).toBeTruthy()
@@ -244,40 +251,58 @@ export default function transformer(fileInfo, api) {
 
     // assert.property -> expect(prop in obj).toBeTruthy()
     ast.find(j.CallExpression, getAssertionExpression('property'))
-        .replaceWith(path => makeExpectation('toBeTruthy', j.binaryExpression('in', path.value.arguments[1], path.value.arguments[0])));
+        .replaceWith(path => makeExpectation('toBeTruthy',
+            j.binaryExpression('in', path.value.arguments[1], path.value.arguments[0]))
+        );
 
     // assert.notProperty -> expect(prop in obj).toBeFalsy()
     ast.find(j.CallExpression, getAssertionExpression('notProperty'))
-        .replaceWith(path => makeExpectation('toBeFalsy', j.binaryExpression('in', path.value.arguments[1], path.value.arguments[0])));
+        .replaceWith(path => makeExpectation('toBeFalsy',
+            j.binaryExpression('in', path.value.arguments[1], path.value.arguments[0]))
+        );
 
     // assert.isArray -> expect(Array.isArray).toBe(true)
     ast.find(j.CallExpression, getAssertionExpression('isArray'))
         .replaceWith(path => makeExpectation('toBe',
-            j.callExpression(j.memberExpression(j.identifier('Array'), j.identifier('isArray')), [path.value.arguments[0]]),
+            j.callExpression(
+                j.memberExpression(j.identifier('Array'), j.identifier('isArray')),
+                [path.value.arguments[0]]
+            ),
             j.literal(true)
         ));
 
     // assert.isArray -> expect(Array.isArray).toBe(false)
     ast.find(j.CallExpression, getAssertionExpression('isNotArray'))
         .replaceWith(path => makeNegativeExpectation('toBe',
-            j.callExpression(j.memberExpression(j.identifier('Array'), j.identifier('isArray')), [path.value.arguments[0]]),
+            j.callExpression(
+                j.memberExpression(j.identifier('Array'), j.identifier('isArray')),
+                [path.value.arguments[0]]
+            ),
             j.literal(true)
         ));
 
     // assert.typeOf(foo, Bar) -> expect(typeof foo).toBe(Bar)
     ast.find(j.CallExpression, getAssertionExpression('typeOf'))
-        .replaceWith(path => makeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), path.value.arguments[1]));
+        .replaceWith(path => makeExpectation('toBe',
+            j.unaryExpression('typeof', path.value.arguments[0]), path.value.arguments[1])
+        );
 
     // assert.notTypeOf(foo, Bar) -> expect(typeof foo).not.toBe(Bar)
     ast.find(j.CallExpression, getAssertionExpression('notTypeOf'))
-        .replaceWith(path => makeNegativeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), path.value.arguments[1]));
+        .replaceWith(path => makeNegativeExpectation('toBe',
+            j.unaryExpression('typeof', path.value.arguments[0]), path.value.arguments[1])
+        );
 
     chaiAssertTypeofs.forEach(({ assert, type }) => {
         ast.find(j.CallExpression, getAssertionExpression(assert))
-            .replaceWith(path => makeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), j.literal(type)));
+            .replaceWith(path => makeExpectation('toBe',
+                j.unaryExpression('typeof', path.value.arguments[0]), j.literal(type))
+            );
 
         ast.find(j.CallExpression, getAssertionExpression(assert.replace(/^is/, 'isNot')))
-            .replaceWith(path => makeNegativeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), j.literal(type)));
+            .replaceWith(path => makeNegativeExpectation('toBe',
+                j.unaryExpression('typeof', path.value.arguments[0]), j.literal(type))
+            );
     });
 
     // assert.lengthOf -> expect(*.length).toBe()
@@ -293,7 +318,10 @@ export default function transformer(fileInfo, api) {
         const expectation = isNegative ? `is${check.substring(5)}` : check;
         ast.find(j.CallExpression, getAssertionExpression(check))
             .replaceWith(path => (isNegative ? makeNegativeExpectation : makeExpectation)('toBe',
-                j.callExpression(j.memberExpression(j.identifier('Object'), j.identifier(expectation)), [path.value.arguments[0]]),
+                j.callExpression(
+                    j.memberExpression(j.identifier('Object'), j.identifier(expectation)),
+                    [path.value.arguments[0]]
+                ),
                 j.literal(true)
             ));
     });

--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -185,7 +185,7 @@ export default function transformer(fileInfo, api) {
         return fileInfo.source;
     }
 
-    const logWarning = (msg, node) => logger(fileInfo, msg, node);
+    const logWarning = (msg, path) => logger(fileInfo, msg, path);
 
     const makeExpectation = (identifier, actual, expectation = []) => j.callExpression(j.memberExpression(
             j.callExpression(j.identifier('expect'), [actual]),
@@ -217,7 +217,7 @@ export default function transformer(fileInfo, api) {
 
     unsupportedAssertions.forEach(assertion => {
         ast.find(j.CallExpression, getAssertionExpression(assertion)).forEach(path => {
-            logWarning(`Unsupported Chai Assertion "${assertion}" found at line ${path.value.loc.start.line}`);
+            logWarning(`Unsupported Chai Assertion "${assertion}".`, path);
         });
     });
 

--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -1,0 +1,310 @@
+import detectQuoteStyle from '../utils/quote-style';
+import logger from '../utils/logger';
+import { removeRequireAndImport } from '../utils/imports';
+
+const getAssertionExpression = identifier => ({
+    type: 'CallExpression',
+    callee: {
+        type: 'MemberExpression',
+        object: {
+            type: 'Identifier',
+            name: 'assert',
+        },
+        property: {
+            type: 'Identifier',
+            name: identifier,
+        },
+    },
+});
+
+const assertToExpectMapping = [
+    {
+        assert: 'ok',
+        expect: 'toBeTruthy',
+        ignoreExpectedValue: true,
+    },
+    {
+        assert: 'notOk',
+        expect: 'toBeFalsy',
+        ignoreExpectedValue: true,
+    },
+    {
+        assert: 'isOk',
+        expect: 'toBeTruthy',
+        ignoreExpectedValue: true,
+    },
+    {
+        assert: 'isNotOk',
+        expect: 'toBeFalsy',
+        ignoreExpectedValue: true,
+    },
+    {
+        assert: 'equal',
+        expect: 'toEqual',
+        includeNegative: 'notEqual',
+    },
+    {
+        assert: 'strictEqual',
+        expect: 'toBe',
+        includeNegative: 'notStrictEqual',
+    },
+    {
+        assert: 'deepEqual',
+        expect: 'toEqual',
+        includeNegative: 'notDeepEqual',
+    },
+    {
+        assert: 'isAbove',
+        expect: 'toBeGreaterThan',
+    },
+    {
+        assert: 'isAtLeast',
+        expect: 'toBeGreaterThanOrEqual',
+    },
+    {
+        assert: 'isBelow',
+        expect: 'toBeLessThan',
+    },
+    {
+        assert: 'isAtMost',
+        expect: 'toBeLessThanOrEqual',
+    },
+    {
+        assert: 'isTrue',
+        expect: 'toBe',
+        expectedOverride: true,
+        includeNegative: 'isNotTrue',
+    },
+    {
+        assert: 'isFalse',
+        expect: 'toBe',
+        expectedOverride: false,
+        includeNegative: 'isNotFalse',
+    },
+    {
+        assert: 'isNull',
+        expect: 'toBeNull',
+        ignoreExpectedValue: true,
+        includeNegative: 'isNotNull',
+    },
+    {
+        assert: 'isNaN',
+        expect: 'toBe',
+        ignoreExpectedValue: true,
+        expectedOverride: 'NaN',
+        includeNegative: 'isNotNaN',
+    },
+    {
+        assert: 'isDefined',
+        expect: 'toBeDefined',
+        ignoreExpectedValue: true,
+        includeNegative: 'isUndefined',
+    },
+    {
+        assert: 'instanceOf',
+        expect: 'toBeInstanceOf',
+        includeNegative: 'notInstanceOf',
+    },
+    {
+        assert: 'include',
+        expect: 'toContain',
+        includeNegative: 'notInclude',
+    },
+    {
+        assert: 'match',
+        expect: 'toMatch',
+        includeNegative: 'notMatch',
+    },
+    {
+        assert: 'throws',
+        expect: 'toThrow',
+        ignoreExpectedValue: true,
+        includeNegative: 'doesNotThrow',
+    },
+    {
+        assert: 'sameMembers',
+        expect: 'toEqual',
+    },
+    {
+        assert: 'sameDeepMembers',
+        expect: 'toEqual',
+    },
+];
+
+const objectChecks = [
+    'isExtensible',
+    'isNotExtensible',
+    'isSealed',
+    'isNotSealed',
+    'isFrozen',
+    'isNotFrozen',
+];
+
+/**
+ * Type checking
+ */
+const chaiAssertTypeofs = [
+    { assert: 'isFunction', type: 'function' },
+    { assert: 'isObject', type: 'object' },
+    { assert: 'isString', type: 'string' },
+    { assert: 'isNumber', type: 'number' },
+    { assert: 'isBoolean', type: 'boolean' },
+];
+
+const getArguments = (path, ignoreExpectedValue, expectedOverride) => {
+    const [actual, originalExpectation] = path.value.arguments;
+    const expectation = !ignoreExpectedValue ? (expectedOverride || originalExpectation) : undefined;
+    return expectation ? [actual, expectation] : [actual];
+};
+
+const unsupportedAssertions = [
+    'deepProperty',
+    'notDeepProperty',
+    'deepPropertyVal',
+    'deepPropertyNotVal',
+    'operator',
+    'includeMembers',
+    'includeDeepMembers',
+    'changes',
+    'doesNotChange',
+    'increases',
+    'doesNotIncrease',
+    'decreases',
+    'doesNotDecrease',
+    'ifError',
+];
+
+export default function transformer(fileInfo, api) {
+    const j = api.jscodeshift;
+    const ast = j(fileInfo.source);
+
+    const testFunctionName = removeRequireAndImport(j, ast, 'chai', 'assert');
+
+    if (!testFunctionName) {
+        // No Chai require/import were found
+        return fileInfo.source;
+    }
+
+    const logWarning = (msg, node) => logger(fileInfo, msg, node);
+
+    const makeExpectation = (identifier, actual, expectation = []) => j.callExpression(j.memberExpression(
+            j.callExpression(j.identifier('expect'), [actual]),
+            j.identifier(identifier)
+        ), Array.isArray(expectation) ? expectation : [expectation]);
+
+    const makeNegativeExpectation = (identifier, actual, expectation = []) => j.callExpression(j.memberExpression(
+            j.memberExpression(
+                j.callExpression(j.identifier('expect'), [actual]),
+                j.identifier('not')
+            ),
+            j.identifier(identifier)
+        ), Array.isArray(expectation) ? expectation : [expectation]);
+
+    assertToExpectMapping.forEach(({ assert, expect, ignoreExpectedValue, includeNegative, expectedOverride }) => {
+        let override;
+        if (expectedOverride) {
+            override = typeof expectedOverride === 'boolean' ? j.literal(expectedOverride) : j.identifier(expectedOverride);
+        }
+
+        ast.find(j.CallExpression, getAssertionExpression(assert))
+            .replaceWith(path => makeExpectation(expect, ...getArguments(path, ignoreExpectedValue, override)));
+
+        if (includeNegative) {
+            ast.find(j.CallExpression, getAssertionExpression(includeNegative))
+                .replaceWith(path => makeNegativeExpectation(expect, ...getArguments(path, ignoreExpectedValue, override)));
+        }
+    });
+
+    unsupportedAssertions.forEach(assertion => {
+        ast.find(j.CallExpression, getAssertionExpression(assertion)).forEach(path => {
+            logWarning(`Unsupported Chai Assertion "${assertion}" found at line ${path.value.loc.start.line}`);
+        });
+    });
+
+    ['approximately', 'closeTo'].forEach(assertion => {
+        ast.find(j.CallExpression, getAssertionExpression(assertion))
+            .replaceWith(path => makeExpectation('toBeCloseTo', path.value.arguments[0], path.value.arguments.slice(1, 3)));
+    });
+
+    // assert.fail -> expect(false).toBeTruthy()
+    ast.find(j.CallExpression, getAssertionExpression('fail'))
+        .replaceWith(path => makeExpectation('toBe', j.literal(false), j.literal(true)));
+
+    // assert.propertyVal -> expect(*.[prop]).toBe()
+    ast.find(j.CallExpression, getAssertionExpression('propertyVal')).replaceWith(path => {
+        const [obj, prop, value] = path.value.arguments;
+        return makeExpectation('toBe', j.memberExpression(obj, prop), value);
+    });
+
+    // assert.propertyNotVal -> expect(*.[prop]).not.toBe()
+    ast.find(j.CallExpression, getAssertionExpression('propertyNotVal')).replaceWith(path => {
+        const [obj, prop, value] = path.value.arguments;
+        return makeNegativeExpectation('toBe', j.memberExpression(obj, prop), value);
+    });
+
+    // assert.property -> expect(prop in obj).toBeTruthy()
+    ast.find(j.CallExpression, getAssertionExpression('property'))
+        .replaceWith(path => makeExpectation('toBeTruthy', j.binaryExpression('in', path.value.arguments[1], path.value.arguments[0])));
+
+    // assert.notProperty -> expect(prop in obj).toBeFalsy()
+    ast.find(j.CallExpression, getAssertionExpression('notProperty'))
+        .replaceWith(path => makeExpectation('toBeFalsy', j.binaryExpression('in', path.value.arguments[1], path.value.arguments[0])));
+
+    // assert.isArray -> expect(Array.isArray).toBe(true)
+    ast.find(j.CallExpression, getAssertionExpression('isArray'))
+        .replaceWith(path => makeExpectation('toBe',
+            j.callExpression(j.memberExpression(j.identifier('Array'), j.identifier('isArray')), [path.value.arguments[0]]),
+            j.literal(true)
+        ));
+
+    // assert.isArray -> expect(Array.isArray).toBe(false)
+    ast.find(j.CallExpression, getAssertionExpression('isNotArray'))
+        .replaceWith(path => makeNegativeExpectation('toBe',
+            j.callExpression(j.memberExpression(j.identifier('Array'), j.identifier('isArray')), [path.value.arguments[0]]),
+            j.literal(true)
+        ));
+
+    // assert.typeOf(foo, Bar) -> expect(typeof foo).toBe(Bar)
+    ast.find(j.CallExpression, getAssertionExpression('typeOf'))
+        .replaceWith(path => makeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), path.value.arguments[1]));
+
+    // assert.notTypeOf(foo, Bar) -> expect(typeof foo).not.toBe(Bar)
+    ast.find(j.CallExpression, getAssertionExpression('notTypeOf'))
+        .replaceWith(path => makeNegativeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), path.value.arguments[1]));
+
+    chaiAssertTypeofs.forEach(({ assert, type }) => {
+        ast.find(j.CallExpression, getAssertionExpression(assert))
+            .replaceWith(path => makeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), j.literal(type)));
+
+        ast.find(j.CallExpression, getAssertionExpression(assert.replace(/^is/, 'isNot')))
+            .replaceWith(path => makeNegativeExpectation('toBe', j.unaryExpression('typeof', path.value.arguments[0]), j.literal(type)));
+    });
+
+    // assert.lengthOf -> expect(*.length).toBe()
+    ast.find(j.CallExpression, getAssertionExpression('lengthOf'))
+        .replaceWith(path => makeExpectation('toBe',
+            j.memberExpression(path.value.arguments[0], j.identifier('length')),
+            path.value.arguments[1])
+        );
+
+    // Object-specific boolean checks
+    objectChecks.forEach(check => {
+        const isNegative = check.indexOf('isNot') === 0;
+        const expectation = isNegative ? `is${check.substring(5)}` : check;
+        ast.find(j.CallExpression, getAssertionExpression(check))
+            .replaceWith(path => (isNegative ? makeNegativeExpectation : makeExpectation)('toBe',
+                j.callExpression(j.memberExpression(j.identifier('Object'), j.identifier(expectation)), [path.value.arguments[0]]),
+                j.literal(true)
+            ));
+    });
+
+    // assert -> expect().toBeTruthy()
+    ast.find(j.CallExpression, {
+        callee: { type: 'Identifier', name: 'assert' },
+    }).replaceWith(path => makeExpectation('toBeTruthy', path.value.arguments[0]));
+
+    // As Recast is not preserving original quoting, we try to detect it,
+    // and default to something sane.
+    const quote = detectQuoteStyle(j, ast) || 'single';
+    return ast.toSource({ quote });
+}

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -156,19 +156,19 @@ assert.${assertion}(foo, bar, baz);`, 'import { assert } from \'chai\';');
     wrappedPlugin(fileInput);
 
     expect(consoleWarnings).toEqual([
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "deepProperty" found at line 2',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "notDeepProperty" found at line 3',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "deepPropertyVal" found at line 4',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "deepPropertyNotVal" found at line 5',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "operator" found at line 6',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "includeMembers" found at line 7',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "includeDeepMembers" found at line 8',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "changes" found at line 9',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "doesNotChange" found at line 10',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "increases" found at line 11',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "doesNotIncrease" found at line 12',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "decreases" found at line 13',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "doesNotDecrease" found at line 14',
-        'jest-codemods warning: (test.js) Unsupported Chai Assertion "ifError" found at line 15',
+        'jest-codemods warning: (test.js line 2) Unsupported Chai Assertion "deepProperty".',
+        'jest-codemods warning: (test.js line 3) Unsupported Chai Assertion "notDeepProperty".',
+        'jest-codemods warning: (test.js line 4) Unsupported Chai Assertion "deepPropertyVal".',
+        'jest-codemods warning: (test.js line 5) Unsupported Chai Assertion "deepPropertyNotVal".',
+        'jest-codemods warning: (test.js line 6) Unsupported Chai Assertion "operator".',
+        'jest-codemods warning: (test.js line 7) Unsupported Chai Assertion "includeMembers".',
+        'jest-codemods warning: (test.js line 8) Unsupported Chai Assertion "includeDeepMembers".',
+        'jest-codemods warning: (test.js line 9) Unsupported Chai Assertion "changes".',
+        'jest-codemods warning: (test.js line 10) Unsupported Chai Assertion "doesNotChange".',
+        'jest-codemods warning: (test.js line 11) Unsupported Chai Assertion "increases".',
+        'jest-codemods warning: (test.js line 12) Unsupported Chai Assertion "doesNotIncrease".',
+        'jest-codemods warning: (test.js line 13) Unsupported Chai Assertion "decreases".',
+        'jest-codemods warning: (test.js line 14) Unsupported Chai Assertion "doesNotDecrease".',
+        'jest-codemods warning: (test.js line 15) Unsupported Chai Assertion "ifError".',
     ]);
 });

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -54,7 +54,7 @@ const should = require('chai').should;
 );
 
 const mappings = [
-  ['assert.fail(foo, bar, baz);', 'expect(false).toBe(true);'], // TODO: ?
+  ['assert.fail(foo, bar, baz);', 'expect(false).toBe(true);'],
   ['assert.equal(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
   ['assert.notEqual(foo, bar, baz);', 'expect(foo).not.toEqual(bar);'],
   ['assert.strictEqual(foo, bar, baz);', 'expect(foo).toBe(bar);'],

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -1,0 +1,174 @@
+/* eslint-env jest */
+import chalk from 'chalk';
+import { wrapPlugin } from '../utils/test-helpers';
+import plugin from './chai-assert';
+
+chalk.enabled = false;
+
+const wrappedPlugin = wrapPlugin(plugin);
+let consoleWarnings = [];
+beforeEach(() => {
+    consoleWarnings = [];
+    console.warn = v => consoleWarnings.push(v);
+});
+
+function testChanged(msg, source, expectedOutput) {
+    test(msg, () => {
+        const result = wrappedPlugin(source);
+        expect(result).toBe(expectedOutput);
+        expect(consoleWarnings).toEqual([]);
+    });
+}
+
+testChanged('does not change if chai is not imported',
+`
+// @flow
+assert.equal(foo, bar, baz);
+`,
+`
+// @flow
+assert.equal(foo, bar, baz);
+`
+);
+
+testChanged('does not change if assert is not imported from chai',
+`
+// @flow
+import { should } from 'chai';
+`,
+`
+// @flow
+import { should } from 'chai';
+`
+);
+
+testChanged('does not change if assert is not required from chai',
+`
+// @flow
+const should = require('chai').should;
+`,
+`
+// @flow
+const should = require('chai').should;
+`
+);
+
+const mappings = [
+  ['assert.fail(foo, bar, baz);', 'expect(false).toBe(true);'], // TODO: ?
+  ['assert.equal(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+  ['assert.notEqual(foo, bar, baz);', 'expect(foo).not.toEqual(bar);'],
+  ['assert.strictEqual(foo, bar, baz);', 'expect(foo).toBe(bar);'],
+  ['assert.notStrictEqual(foo, bar, baz);', 'expect(foo).not.toBe(bar);'],
+  ['assert.deepEqual(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+  ['assert.notDeepEqual(foo, bar, baz);', 'expect(foo).not.toEqual(bar);'],
+  ['assert.isAbove(foo, bar, baz);', 'expect(foo).toBeGreaterThan(bar);'],
+  ['assert.isAtLeast(foo, bar, baz);', 'expect(foo).toBeGreaterThanOrEqual(bar);'],
+  ['assert.isBelow(foo, bar, baz);', 'expect(foo).toBeLessThan(bar);'],
+  ['assert.isAtMost(foo, bar, baz);', 'expect(foo).toBeLessThanOrEqual(bar);'],
+  ['assert.isTrue(foo, bar, baz);', 'expect(foo).toBe(true);'],
+  ['assert.isNotTrue(foo, bar, baz);', 'expect(foo).not.toBe(true);'],
+  ['assert.isFalse(foo, bar, baz);', 'expect(foo).toBe(bar);'],
+  ['assert.isNotFalse(foo, bar, baz);', 'expect(foo).not.toBe(bar);'],
+  ['assert.isNull(foo, bar, baz);', 'expect(foo).toBeNull();'],
+  ['assert.isNotNull(foo, bar, baz);', 'expect(foo).not.toBeNull();'],
+  ['assert.isNaN(foo, bar, baz);', 'expect(foo).toBe();'],
+  ['assert.isNotNaN(foo, bar, baz);', 'expect(foo).not.toBe();'],
+  ['assert.isUndefined(foo, bar, baz);', 'expect(foo).not.toBeDefined();'],
+  ['assert.isDefined(foo, bar, baz);', 'expect(foo).toBeDefined();'],
+  ['assert.isFunction(foo, bar, baz);', 'expect(typeof foo).toBe(\'function\');'],
+  ['assert.isNotFunction(foo, bar, baz);', 'expect(typeof foo).not.toBe(\'function\');'],
+  ['assert.isObject(foo, bar, baz);', 'expect(typeof foo).toBe(\'object\');'],
+  ['assert.isNotObject(foo, bar, baz);', 'expect(typeof foo).not.toBe(\'object\');'],
+  ['assert.isArray(foo, bar, baz);', 'expect(Array.isArray(foo)).toBe(true);'],
+  ['assert.isNotArray(foo, bar, baz);', 'expect(Array.isArray(foo)).not.toBe(true);'],
+  ['assert.isString(foo, bar, baz);', 'expect(typeof foo).toBe(\'string\');'],
+  ['assert.isNotString(foo, bar, baz);', 'expect(typeof foo).not.toBe(\'string\');'],
+  ['assert.isNumber(foo, bar, baz);', 'expect(typeof foo).toBe(\'number\');'],
+  ['assert.isNotNumber(foo, bar, baz);', 'expect(typeof foo).not.toBe(\'number\');'],
+  ['assert.isBoolean(foo, bar, baz);', 'expect(typeof foo).toBe(\'boolean\');'],
+  ['assert.isNotBoolean(foo, bar, baz);', 'expect(typeof foo).not.toBe(\'boolean\');'],
+  ['assert.typeOf(foo, bar, baz);', 'expect(typeof foo).toBe(bar);'],
+  ['assert.notTypeOf(foo, bar, baz);', 'expect(typeof foo).not.toBe(bar);'],
+  ['assert.instanceOf(foo, bar, baz);', 'expect(foo).toBeInstanceOf(bar);'],
+  ['assert.notInstanceOf(foo, bar, baz);', 'expect(foo).not.toBeInstanceOf(bar);'],
+  ['assert.include(foo, bar, baz);', 'expect(foo).toContain(bar);'],
+  ['assert.notInclude(foo, bar, baz);', 'expect(foo).not.toContain(bar);'],
+  ['assert.match(foo, bar, baz);', 'expect(foo).toMatch(bar);'],
+  ['assert.notMatch(foo, bar, baz);', 'expect(foo).not.toMatch(bar);'],
+  ['assert.property(foo, bar, baz);', 'expect(bar in foo).toBeTruthy();'],
+  ['assert.notProperty(foo, bar, baz);', 'expect(bar in foo).toBeFalsy();'],
+  ['assert.propertyVal(foo, bar, baz);', 'expect(foo.bar).toBe(baz);'],
+  ['assert.propertyNotVal(foo, bar, baz);', 'expect(foo.bar).not.toBe(baz);'],
+  ['assert.lengthOf(foo, bar, baz);', 'expect(foo.length).toBe(bar);'],
+  ['assert.throws(foo, bar, baz);', 'expect(foo).toThrow();'],
+  ['assert.doesNotThrow(foo, bar, baz);', 'expect(foo).not.toThrow();'],
+  ['assert.closeTo(foo, bar, baz);', 'expect(foo).toBeCloseTo(bar, baz);'],
+  ['assert.approximately(foo, bar, baz);', 'expect(foo).toBeCloseTo(bar, baz);'],
+  ['assert.sameMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+  ['assert.sameDeepMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+  ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],
+  ['assert.isNotExtensible(foo);', 'expect(Object.isExtensible(foo)).not.toBe(true);'],
+  ['assert.isSealed(foo);', 'expect(Object.isSealed(foo)).toBe(true);'],
+  ['assert.isNotSealed(foo);', 'expect(Object.isSealed(foo)).not.toBe(true);'],
+  ['assert.isFrozen(foo);', 'expect(Object.isFrozen(foo)).toBe(true);'],
+  ['assert.isNotFrozen(foo);', 'expect(Object.isFrozen(foo)).not.toBe(true);'],
+];
+
+const mappingTest = mappings.reduce((test, [assert, expect]) => ({
+    input: `
+${test.input}
+${assert}
+`,
+    output: `
+${test.output}
+${expect}
+`,
+}), { input: `
+// @flow
+import { assert } from 'chai';`,
+    output: `
+// @flow`,
+});
+
+testChanged('mappings', mappingTest.input, mappingTest.output);
+
+test('not supported assertions', () => {
+    const unsupportedAssertions = [
+        'deepProperty',
+        'notDeepProperty',
+        'deepPropertyVal',
+        'deepPropertyNotVal',
+        'operator',
+        'includeMembers',
+        'includeDeepMembers',
+        'changes',
+        'doesNotChange',
+        'increases',
+        'doesNotIncrease',
+        'decreases',
+        'doesNotDecrease',
+        'ifError',
+    ];
+
+    const fileInput = unsupportedAssertions.reduce((input, assertion) => `${input}
+assert.${assertion}(foo, bar, baz);`, 'import { assert } from \'chai\';');
+
+    wrappedPlugin(fileInput);
+
+    expect(consoleWarnings).toEqual([
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "deepProperty" found at line 2',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "notDeepProperty" found at line 3',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "deepPropertyVal" found at line 4',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "deepPropertyNotVal" found at line 5',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "operator" found at line 6',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "includeMembers" found at line 7',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "includeDeepMembers" found at line 8',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "changes" found at line 9',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "doesNotChange" found at line 10',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "increases" found at line 11',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "doesNotIncrease" found at line 12',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "decreases" found at line 13',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "doesNotDecrease" found at line 14',
+        'jest-codemods warning: (test.js) Unsupported Chai Assertion "ifError" found at line 15',
+    ]);
+});

--- a/src/utils/imports.test.js
+++ b/src/utils/imports.test.js
@@ -30,7 +30,7 @@ describe('removeRequireAndImport', () => {
         `);
     });
 
-    it('removes require statments with given specifier', () => {
+    it('removes require statements with given specifier', () => {
         const ast = j(`
             const x = require('foo').bar;
             x();

--- a/src/utils/imports.test.js
+++ b/src/utils/imports.test.js
@@ -30,6 +30,31 @@ describe('removeRequireAndImport', () => {
         `);
     });
 
+    it('removes require statments with given specifier', () => {
+        const ast = j(`
+            const x = require('foo').bar;
+            x();
+        `);
+        const removedVariableName = removeRequireAndImport(j, ast, 'foo', 'bar');
+        expect(removedVariableName).toBe('x');
+        expect(ast.toSource()).toEqual(`
+            x();
+        `);
+    });
+
+    it('retains require statements without given specifier', () => {
+        const ast = j(`
+            const x = require('foo').bar;
+            x();
+        `);
+        const removedVariableName = removeRequireAndImport(j, ast, 'foo', 'bop');
+        expect(removedVariableName).toBeNull();
+        expect(ast.toSource()).toEqual(`
+            const x = require('foo').bar;
+            x();
+        `);
+    });
+
     it('removes import statements', () => {
         const ast = j(`
             import xx from 'baz';
@@ -38,6 +63,43 @@ describe('removeRequireAndImport', () => {
         const removedVariableName = removeRequireAndImport(j, ast, 'baz');
         expect(removedVariableName).toBe('xx');
         expect(ast.toSource()).toEqual(`
+            xx();
+        `);
+    });
+
+    it('removes import statements with specifiers', () => {
+        const ast = j(`
+            import { xx } from 'baz';
+            xx();
+        `);
+        const removedVariableName = removeRequireAndImport(j, ast, 'baz', 'xx');
+        expect(removedVariableName).toBe('xx');
+        expect(ast.toSource()).toEqual(`
+            xx();
+        `);
+    });
+
+    it('removes import statements with specifiers', () => {
+        const ast = j(`
+            import { xx as foo } from 'baz';
+            xx();
+        `);
+        const removedVariableName = removeRequireAndImport(j, ast, 'baz', 'xx');
+        expect(removedVariableName).toBe('foo');
+        expect(ast.toSource()).toEqual(`
+            xx();
+        `);
+    });
+
+    it('retains import statements without specifiers', () => {
+        const ast = j(`
+            import { xx } from 'baz';
+            xx();
+        `);
+        const removedVariableName = removeRequireAndImport(j, ast, 'baz', 'yy');
+        expect(removedVariableName).toBeNull();
+        expect(ast.toSource()).toEqual(`
+            import { xx } from 'baz';
             xx();
         `);
     });


### PR DESCRIPTION
**Changes:**

* Adds a question to the CLI after choosing *Mocha* or *All* to choose whether or not to also run *Chai Assertion* transforms.
* Adds an option to import util functions to ensure that a particular specifier is being imported or not.

**Additions:**

* Adds support to convert as much of the Chai Assert API as makes sense.

**Notes:**

*Should* and *Expect* syntax from Chai are quite different from *Assert*, and will require a separate transformer. 

The following assertion methods were left off, as they're a bit complex and there are maybe better ways of writing tests than using these:

- deepProperty
- notDeepProperty
- deepPropertyVal
- deepPropertyNotVal
- operator
- includeMembers
- includeDeepMembers
- changes
- doesNotChange
- increases
- doesNotIncrease
- decreases
- doesNotDecrease
- ifError
