### PR TITLE
Fix removal of imports without variable declaration

### DIFF
--- a/src/utils/imports.js
+++ b/src/utils/imports.js
@@ -25,6 +25,9 @@ export function hasRequireOrImport(j, ast, pkg) {
 }
 
 function findParentVariableDeclaration(path) {
+    if (!path) {
+        return null;
+    }
     if (path.value.type === 'VariableDeclarator') {
         return path;
     }
@@ -53,16 +56,24 @@ export function removeRequireAndImport(j, ast, pkg, specifier) {
         const variableDeclarationPath = findParentVariableDeclaration(p);
         const parentMember = findParentPathMemberRequire(p);
         if (!specifier || (parentMember && parentMember.name === specifier)) {
-            localName = variableDeclarationPath.value.id.name;
-            variableDeclarationPath.prune();
+            if (variableDeclarationPath) {
+                localName = variableDeclarationPath.value.id.name;
+                variableDeclarationPath.prune();
+            } else {
+                p.prune();
+            }
         }
     });
 
     findImports(j, ast, pkg)
     .forEach(p => {
-        importName = p.value.specifiers[0].imported && p.value.specifiers[0].imported.name;
+        const pathSpecifier = p.value.specifiers[0];
+        importName = pathSpecifier && pathSpecifier.imported && pathSpecifier.imported.name;
+
         if (!specifier || importName === specifier) {
-            localName = p.value.specifiers[0].local.name;
+            if (pathSpecifier) {
+                localName = pathSpecifier.local.name;
+            }
             p.prune();
         }
     });

--- a/src/utils/imports.test.js
+++ b/src/utils/imports.test.js
@@ -18,6 +18,18 @@ describe('removeRequireAndImport', () => {
         `);
     });
 
+    it('removes require statements without local name', () => {
+        const ast = j(`
+            require('foo');
+            console.log('yes');
+        `);
+        const removedVariableName = removeRequireAndImport(j, ast, 'foo');
+        expect(removedVariableName).toBeNull();
+        expect(ast.toSource()).toEqual(`
+            console.log('yes');
+        `);
+    });
+
     it('removes require statements with calls', () => {
         const ast = j(`
             const x = require('foo').bar();
@@ -45,12 +57,14 @@ describe('removeRequireAndImport', () => {
     it('retains require statements without given specifier', () => {
         const ast = j(`
             const x = require('foo').bar;
+            require('foo').baz();
             x();
         `);
         const removedVariableName = removeRequireAndImport(j, ast, 'foo', 'bop');
         expect(removedVariableName).toBeNull();
         expect(ast.toSource()).toEqual(`
             const x = require('foo').bar;
+            require('foo').baz();
             x();
         `);
     });
@@ -64,6 +78,18 @@ describe('removeRequireAndImport', () => {
         expect(removedVariableName).toBe('xx');
         expect(ast.toSource()).toEqual(`
             xx();
+        `);
+    });
+
+    it('removes import statements without local name', () => {
+        const ast = j(`
+            import 'baz';
+            console.log('yes');
+        `);
+        const removedVariableName = removeRequireAndImport(j, ast, 'baz');
+        expect(removedVariableName).toBeNull();
+        expect(ast.toSource()).toEqual(`
+            console.log('yes');
         `);
     });
 


### PR DESCRIPTION
@paularmstrong I've tried testing this on an old mocha codebase... Looks pretty good.

I've found two things:
1) small bug in the CLI due to mismatch between `chai` and `chai-assert` (line 82), see https://github.com/skovhus/jest-codemods/commit/b59f12dd886e9a5b7d0d9cb9f9721d8f20d2414a
2) I'm not sure if it is valid but I found some code that requires chai without a variable declaration, like this `require('chai').should();``

I'm not sure what we should do for 2. Right now the codemod crashes as there is not variable declaration. If we fix it like I've done here, then we don't return any `localName`, as there is none. But actually we removed the require/import statement.

Any suggestions?