### PR TITLE
Allow destructuring tape/ava test callback argument closes #23

### DIFF
--- a/src/transformers/ava.js
+++ b/src/transformers/ava.js
@@ -7,7 +7,7 @@ import { removeRequireAndImport } from '../utils/imports';
 import detectIncompatiblePackages from '../utils/incompatible-packages';
 import { PROP_WITH_SECONDS_ARGS } from '../utils/consts';
 import {
-    detectUnsupportedNaming, rewriteAssertionsAndTestArgument,
+    detectUnsupportedNaming, rewriteAssertionsAndTestArgument, rewriteDestructuredTArgument,
 } from '../utils/tape-ava-helpers';
 import {
     getIdentifierFromExpression, getMemberExpressionElements,
@@ -69,6 +69,8 @@ export default function avaToJest(fileInfo, api) {
     const logWarning = (msg, node) => logger(fileInfo, msg, node);
 
     const transforms = [
+        () => rewriteDestructuredTArgument(fileInfo, j, ast, testFunctionName),
+
         () => detectUnsupportedNaming(fileInfo, j, ast, testFunctionName),
 
         function updateAssertions() {

--- a/src/transformers/ava.test.js
+++ b/src/transformers/ava.test.js
@@ -253,6 +253,26 @@ it(async function () {
 });
 `);
 
+testChanged('destructured test argument',
+`
+import test from 'ava';
+test(({ok}) => {
+    ok('msg');
+});
+test('my test', ({is}) => {
+    is('msg', 'other msg');
+});
+`,
+`
+it(() => {
+    expect('msg').toBeTruthy();
+});
+it('my test', () => {
+    expect('msg').toBe('other msg');
+});
+`
+);
+
 test('not supported warnings: skipping test setup/teardown hooks', () => {
     wrappedPlugin(`
         import test from 'ava'

--- a/src/transformers/tape.js
+++ b/src/transformers/tape.js
@@ -6,7 +6,7 @@ import { removeRequireAndImport } from '../utils/imports';
 import detectIncompatiblePackages from '../utils/incompatible-packages';
 import { PROP_WITH_SECONDS_ARGS } from '../utils/consts';
 import {
-    detectUnsupportedNaming, rewriteAssertionsAndTestArgument,
+    detectUnsupportedNaming, rewriteAssertionsAndTestArgument, rewriteDestructuredTArgument,
 } from '../utils/tape-ava-helpers';
 import logger from '../utils/logger';
 import proxyquireTransformer from '../utils/proxyquire';
@@ -100,6 +100,8 @@ export default function tapeToJest(fileInfo, api) {
     const logWarning = (msg, node) => logger(fileInfo, msg, node);
 
     const transforms = [
+        () => rewriteDestructuredTArgument(fileInfo, j, ast, testFunctionName),
+
         () => detectUnsupportedNaming(fileInfo, j, ast, testFunctionName),
 
         function detectUnsupportedFeatures() {

--- a/src/transformers/tape.test.js
+++ b/src/transformers/tape.test.js
@@ -318,6 +318,20 @@ it(() => {
 `
 );
 
+testChanged('destructured test argument',
+`
+import test from 'tape';
+test(({ok}) => {
+    ok('msg');
+});
+`,
+`
+it(() => {
+    expect('msg').toBeTruthy();
+});
+`
+);
+
 test('not supported warnings: createStream', () => {
     wrappedPlugin(`
         import test from 'tape';

--- a/src/transformers/tape.test.js
+++ b/src/transformers/tape.test.js
@@ -324,10 +324,16 @@ import test from 'tape';
 test(({ok}) => {
     ok('msg');
 });
+test('my test', ({equal}) => {
+    equal('msg', 'other msg');
+});
 `,
 `
 it(() => {
     expect('msg').toBeTruthy();
+});
+it('my test', () => {
+    expect('msg').toBe('other msg');
 });
 `
 );

--- a/src/transformers/tape.test.js
+++ b/src/transformers/tape.test.js
@@ -441,3 +441,15 @@ test('warns about some conflicting packages', () => {
         'jest-codemods warning: (test.js) Usage of package "testdouble" might be incompatible with Jest',
     ]);
 });
+
+test('graciously warns about unknown destructured assertions', () => {
+    wrappedPlugin(`
+        import test from 'tape';
+        test(({plan}) => {
+            plan('msg');
+        });
+    `);
+    expect(consoleWarnings).toEqual([
+        'jest-codemods warning: (test.js) "t.plan" is currently not supported',
+    ]);
+});

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
 
 export default function logWarning(fileInfo, msg, node) {
-    const lineInfo = node ? ` line ${node.value.loc.start.line}` : '';
+    // If the node has been previously modified by the codemod (for instance, when using
+    // destructuring) the node doesn't have a loc anymore
+    const lineInfo = node && node.value.loc ? ` line ${node.value.loc.start.line}` : '';
     console.warn(chalk.red(`jest-codemods warning: (${fileInfo.path}${lineInfo}) ${msg}`));
 }


### PR DESCRIPTION
This seems to work. Sadly, I still have problems when trying to apply the codemod on my app, but I'll investigate this asap!

I'm not super happy of the code, the second part of the function is really redundant with some other stuff you wrote, but I guess I'd rather submit first this PR, and then see how we can make it cleaner!