### PR TITLE
Tape/AVA: Use test keyword instead of it/fit/xit

### DIFF
--- a/src/transformers/ava.js
+++ b/src/transformers/ava.js
@@ -52,9 +52,8 @@ const avaToJestMethods = {
     after: 'afterAll',
     beforeEach: 'beforeEach',
     afterEach: 'afterEach',
-
-    skip: 'xit',
-    only: 'fit',
+    skip: 'test.skip',
+    only: 'test.only',
 };
 
 export default function avaToJest(fileInfo, api) {
@@ -145,12 +144,12 @@ export default function avaToJest(fileInfo, api) {
             ast.find(j.CallExpression, {
                 callee: { name: testFunctionName },
             }).forEach(p => {
-                p.node.callee.name = 'it';
+                p.node.callee.name = 'test';
                 rewriteAssertionsAndTestArgument(j, p);
             });
 
             function mapPathToJestMethod(p) {
-                let jestMethod = 'it';
+                let jestMethod = 'test';
 
                 // List like ['test', 'serial', 'cb']
                 const avaMethods = getMemberExpressionElements(

--- a/src/transformers/ava.test.js
+++ b/src/transformers/ava.test.js
@@ -71,7 +71,7 @@ test('mapping', (t) => {
 `,
 `
 // @flow
-it('mapping', () => {
+test('mapping', () => {
   const abc = { a: 'a', b: 'b', c: 'c' }
   expect(abc).toBeTruthy()
   expect(abc).toBeTruthy()
@@ -121,7 +121,7 @@ import test from 'ava'
 test.serial(t => {});
 `,
 `
-it(() => {});
+test(() => {});
 `);
 
 testChanged('handles skip/only modifiers and chaining',
@@ -137,13 +137,13 @@ test.only.serial(t => {});
 test.serial.only(t => {});
 `,
 `
-fit(() => {});
-xit(() => {});
+test.only(() => {});
+test.skip(() => {});
 
-xit(() => {});
-xit(() => {});
-fit(() => {});
-fit(() => {});
+test.skip(() => {});
+test.skip(() => {});
+test.only(() => {});
+test.only(() => {});
 `);
 
 testChanged('removes t.pass, but keeps t.fail',
@@ -165,13 +165,13 @@ test.serial.only('handles done.fail and done.pass', t => {
 });
 `,
 `
-it('handles done.fail and done.pass', done => {
+test('handles done.fail and done.pass', done => {
     setTimeout(() => {
         done.fail('no');
     }, 500);
 });
 
-fit('handles done.fail and done.pass', done => {
+test.only('handles done.fail and done.pass', done => {
     setTimeout(() => {
         done.fail('no');
     }, 500);
@@ -188,7 +188,7 @@ test.cb(t => {
 });
 `,
 `
-it(done => {
+test(done => {
     fs.readFile('data.txt', done);
 });
 `);
@@ -214,7 +214,7 @@ function shouldFail2(t, message) {
 }
 `,
 `
-it('should pass', () => {
+test('should pass', () => {
     shouldFail(t, 'hi')
     return shouldFail2(t, 'hi')
 })
@@ -244,12 +244,12 @@ test(async function (t) {
 });
 `,
 `
-it(async () => {
+test(async () => {
     const value = await promiseFn();
     expect(value).toBe(true);
 });
 
-it(async function () {
+test(async function () {
     const value = await promiseFn();
     expect(value).toBe(true);
 });
@@ -266,10 +266,10 @@ test('my test', ({is}) => {
 });
 `,
 `
-it(() => {
+test(() => {
     expect('msg').toBeTruthy();
 });
-it('my test', () => {
+test('my test', () => {
     expect('msg').toBe('other msg');
 });
 `
@@ -330,9 +330,9 @@ test('not supported warnings: non standard argument for test', () => {
 
 test('warns about some conflicting packages', () => {
     wrappedPlugin(`
-        import test from 'ava';
-        import test from 'proxyquire';
-        import test from 'testdouble';
+        import ava from 'ava';
+        import proxyquire from 'proxyquire';
+        import testdouble from 'testdouble';
         test(t => {});
     `);
     expect(consoleWarnings).toEqual([
@@ -351,3 +351,13 @@ test('warns about unknown AVA functions', () => {
         'jest-codemods warning: (test.js line 4) Unknown AVA method "failing"',
     ]);
 });
+
+testChanged('supports renaming non standard import name',
+`
+import foo from 'ava';
+foo(() => {});
+`,
+`
+test(() => {});
+`
+);

--- a/src/transformers/tape.js
+++ b/src/transformers/tape.js
@@ -78,7 +78,6 @@ const tPropertiesUnsupported = new Set([
     'notDeepLooseEqual',
     'notLooseEqual',
     'notLooseEquals',
-
     'skip',
 ]);
 
@@ -219,7 +218,7 @@ export default function tapeToJest(fileInfo, api) {
                             const tapeOptionKey = tapeOption.key.name;
                             const tapeOptionValue = tapeOption.value.value;
                             if (tapeOptionKey === 'skip' && tapeOptionValue === true) {
-                                p.value.callee.name = 'xit';
+                                p.value.callee.name = 'test.skip';
                             }
 
                             if (tapeOptionKey === 'timeout') {
@@ -231,8 +230,8 @@ export default function tapeToJest(fileInfo, api) {
                     }
                 });
 
-                if (p.node.callee.name !== 'xit') {
-                    p.node.callee.name = 'it';
+                if (p.node.callee.name !== 'test.skip') {
+                    p.node.callee.name = 'test';
                 }
 
                 rewriteAssertionsAndTestArgument(j, p);

--- a/src/transformers/tape.test.js
+++ b/src/transformers/tape.test.js
@@ -109,7 +109,7 @@ test((t) => {
 });
 `,
 `
-it(done => {
+test(done => {
     done.fail('msg');
     expect(1).toBeTruthy();
     expect(1).toBeTruthy();
@@ -168,7 +168,7 @@ test("mytest", t => {
 });
 `,
 `
-it("mytest", () => {
+test("mytest", () => {
     expect("msg").toBeTruthy();
 });
 `
@@ -194,19 +194,19 @@ myTapeTest(function(t) {
 });
 `,
 `
-it("mytest", () => {
+test("mytest", () => {
     expect("msg").toBeTruthy();
 });
 
-it(() => {
+test(() => {
     expect("msg").toBeTruthy();
 });
 
-it("mytest", function() {
+test("mytest", function() {
     expect("msg").toBeTruthy();
 });
 
-it(function() {
+test(function() {
     expect("msg").toBeTruthy();
 });
 `
@@ -220,7 +220,7 @@ test('mytest', {objectPrintDepth: 4, skip: false}, t => {
 });
 `,
 `
-it('mytest', () => {
+test('mytest', () => {
     expect('msg').toBeTruthy();
 });
 `
@@ -234,7 +234,7 @@ test('mytest', {objectPrintDepth: 4, skip: true}, t => {
 });
 `,
 `
-xit('mytest', () => {
+test.skip('mytest', () => {
     expect('msg').toBeTruthy();
 });
 `
@@ -249,7 +249,7 @@ test('mytest', t => {
 });
 `,
 `
-it('mytest', () => {
+test('mytest', () => {
     expect(1).toBe(1);
 });
 `
@@ -266,7 +266,7 @@ test(t => {
 });
 `,
 `
-it(done => {
+test(done => {
     setTimeout(() => {
         done();
     }, 500);
@@ -289,11 +289,11 @@ test('handles done.fail and done.pass', t => {
 });
 `,
 `
-it(function(done) {
+test(function(done) {
     done.fail();
 });
 
-it('handles done.fail and done.pass', done => {
+test('handles done.fail and done.pass', done => {
     setTimeout(() => {
         done.fail('no');
     }, 500);
@@ -311,7 +311,7 @@ test(t => {
 });
 `,
 `
-it(() => {
+test(() => {
     expect(myfunc).toThrow();
     expect(myfunc).toThrowError('xxx');
     expect(myfunc).toThrowError(/err_reg_exp/i);
@@ -331,10 +331,10 @@ test('my test', ({equal}) => {
 });
 `,
 `
-it(() => {
+test(() => {
     expect('msg').toBeTruthy();
 });
-it('my test', () => {
+test('my test', () => {
     expect('msg').toBe('other msg');
 });
 `
@@ -447,8 +447,8 @@ test('not supported warnings: non standard argument for test.skip', () => {
 test('warns about some conflicting packages', () => {
     wrappedPlugin(`
         import test from 'tape';
-        import test from 'proxyquire';
-        import test from 'testdouble';
+        import proxyquire from 'proxyquire';
+        import testdouble from 'testdouble';
         test(t => {});
     `);
     expect(consoleWarnings).toEqual([
@@ -464,3 +464,13 @@ test('graciously warns about unknown destructured assertions', () => {
         });
     `);
 });
+
+testChanged('supports renaming non standard import name',
+`
+import foo from 'tape';
+foo(() => {});
+`,
+`
+test(() => {});
+`
+);


### PR DESCRIPTION
Instead of outputting `it`, `fit` and `xit`, the AVA and Tape transformers now output `test`, `test.only` and `test.skip`, in line with the latest Jest API documentation.