### PR TITLE
Importing chai should/ expect transform.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 bin
 dist
+__testfixtures__/

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "babel src -d dist --ignore *.test.js",
+    "build": "babel src -d dist --ignore *.test.js,__testfixtures__",
     "check": "npm run lint && npm run test:cov",
     "clean": "rm -rf lib coverage npm-debug.log dist",
     "lint": "eslint --fix src",
@@ -43,6 +43,7 @@
     "codemods"
   ],
   "dependencies": {
+    "babel-eslint": "^7.2.1",
     "chalk": "~1.1.3",
     "execa": "~0.4.0",
     "globby": "~6.0.0",
@@ -65,7 +66,8 @@
     "collectCoverageFrom": "src/**/*.js",
     "coveragePathIgnorePatterns": [
       "/node_modules/",
-      "/dist/"
+      "/dist/",
+      "/__testfixtures__/"
     ],
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "testEnvironment": "node"

--- a/src/transformers/__testfixtures__/chai-chain.input.js
+++ b/src/transformers/__testfixtures__/chai-chain.input.js
@@ -1,0 +1,23 @@
+describe('Instantiating TextField', () => {
+    it('should set the placeholder correctly', () => {
+        textField.props.placeholder.should.equal(PLACEHOLDER);
+        textField.props.placeholder.should.not.equal(PLACEHOLDER);
+    });
+
+    it('should inherit id prop', () => {
+        dropdown.props.id.should.equal(STANDARD_PROPS.id);
+        dropdown.props.id.should.not.equal(STANDARD_PROPS.id);
+    });
+
+    it('should map open prop to visible prop', () => {
+        dropdown.props.visible.should.Throw(STANDARD_PROPS.open);
+        dropdown.props.id.should.not.Throw(STANDARD_PROPS.id);
+    });
+
+    thing1.equal(thing2);
+});
+
+// simple referencing
+const obj = { foo: 'bar' };
+expect(obj).to.have.property('foo');
+expect(obj).to.have.property('foo', 'bar');

--- a/src/transformers/__testfixtures__/chai-chain.output.js
+++ b/src/transformers/__testfixtures__/chai-chain.output.js
@@ -1,0 +1,23 @@
+describe('Instantiating TextField', () => {
+    it('should set the placeholder correctly', () => {
+        expect(textField.props.placeholder).toBe(PLACEHOLDER);
+        expect(textField.props.placeholder).not.toBe(PLACEHOLDER);
+    });
+
+    it('should inherit id prop', () => {
+        expect(dropdown.props.id).toBe(STANDARD_PROPS.id);
+        expect(dropdown.props.id).not.toBe(STANDARD_PROPS.id);
+    });
+
+    it('should map open prop to visible prop', () => {
+        expect(dropdown.props.visible).toThrowError(STANDARD_PROPS.open);
+        expect(dropdown.props.id).not.toThrowError(STANDARD_PROPS.id);
+    });
+
+    thing1.equal(thing2);
+});
+
+// simple referencing
+const obj = { foo: 'bar' };
+expect(obj.hasOwnProperty('foo')).toBeTruthy();
+expect(obj['foo']).toEqual('bar');

--- a/src/transformers/__testfixtures__/chai-chain/a-an.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/a-an.input.js
@@ -1,0 +1,8 @@
+expect('test').to.be.a('string');
+expect({ foo: 'bar' }).to.be.an('object');
+expect(null).to.be.a('null');
+expect(undefined).to.be.an('undefined');
+expect(new Error()).to.be.an('error');
+expect(new Promise()).to.be.a('promise');
+expect(new Float32Array()).to.be.a('float32array');
+expect(Symbol()).to.be.a('symbol');

--- a/src/transformers/__testfixtures__/chai-chain/a-an.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/a-an.output.js
@@ -1,0 +1,8 @@
+expect(typeof 'test').toBe('string');
+expect(typeof { foo: 'bar' }).toBe('object');
+expect(null).toBeNull();
+expect(undefined).toBeUndefined();
+expect(typeof new Error()).toBe('error');
+expect(typeof new Promise()).toBe('promise');
+expect(typeof new Float32Array()).toBe('float32array');
+expect(typeof Symbol()).toBe('symbol');

--- a/src/transformers/__testfixtures__/chai-chain/above.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/above.input.js
@@ -1,0 +1,1 @@
+expect(10).to.be.above(5);

--- a/src/transformers/__testfixtures__/chai-chain/above.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/above.output.js
@@ -1,0 +1,1 @@
+expect(10).toBeGreaterThan(5);

--- a/src/transformers/__testfixtures__/chai-chain/below.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/below.input.js
@@ -1,0 +1,1 @@
+expect(5).to.be.below(10);

--- a/src/transformers/__testfixtures__/chai-chain/below.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/below.output.js
@@ -1,0 +1,1 @@
+expect(5).toBeLessThan(10);

--- a/src/transformers/__testfixtures__/chai-chain/eql.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/eql.input.js
@@ -1,0 +1,2 @@
+expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
+expect([1, 2, 3]).to.eql([1, 2, 3]);

--- a/src/transformers/__testfixtures__/chai-chain/eql.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/eql.output.js
@@ -1,0 +1,2 @@
+expect({ foo: 'bar' }).toEqual({ foo: 'bar' });
+expect([1, 2, 3]).toEqual([1, 2, 3]);

--- a/src/transformers/__testfixtures__/chai-chain/equal.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/equal.input.js
@@ -1,0 +1,5 @@
+expect('hello').to.equal('hello');
+expect(42).to.equal(42);
+expect(1).to.not.equal(true);
+expect({ foo: 'bar' }).to.not.equal({ foo: 'bar' });
+expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });

--- a/src/transformers/__testfixtures__/chai-chain/equal.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/equal.output.js
@@ -1,0 +1,5 @@
+expect('hello').toBe('hello');
+expect(42).toBe(42);
+expect(1).not.toBe(true);
+expect({ foo: 'bar' }).not.toBe({ foo: 'bar' });
+expect({ foo: 'bar' }).toEqual({ foo: 'bar' });

--- a/src/transformers/__testfixtures__/chai-chain/exist-defined.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/exist-defined.input.js
@@ -1,0 +1,8 @@
+expect(foo).to.exist;
+expect(bar).to.not.exist;
+expect(baz).to.not.exist;
+expect(input).exist;
+
+expect(foo).to.be.defined;
+expect(foo).not.to.be.defined;
+expect(foo).to.not.be.defined;

--- a/src/transformers/__testfixtures__/chai-chain/exist-defined.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/exist-defined.output.js
@@ -1,0 +1,8 @@
+expect(foo).toBeDefined();
+expect(bar).toBeFalsy();
+expect(baz).toBeFalsy();
+expect(input).toBeDefined();
+
+expect(foo).toBeDefined();
+expect(foo).not.toBeDefined();
+expect(foo).toBeFalsy();

--- a/src/transformers/__testfixtures__/chai-chain/false.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/false.input.js
@@ -1,0 +1,2 @@
+expect(false).to.be.false;
+expect(0).to.not.be.false;

--- a/src/transformers/__testfixtures__/chai-chain/false.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/false.output.js
@@ -1,0 +1,2 @@
+expect(false).toBe(false);
+expect(0).not.toBe(false);

--- a/src/transformers/__testfixtures__/chai-chain/include-contain.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/include-contain.input.js
@@ -1,0 +1,4 @@
+expect('foobar').to.have.string('bar');
+expect([1, 2, 3]).to.include(2);
+expect('foobar').to.contain('foo');
+expect({ foo: 1, bar: 2 }).to.contain({ bar: 2 });

--- a/src/transformers/__testfixtures__/chai-chain/include-contain.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/include-contain.output.js
@@ -1,0 +1,4 @@
+expect('foobar').toContain('bar');
+expect([1, 2, 3]).toContain(2);
+expect('foobar').toContain('foo');
+expect({ foo: 1, bar: 2 }).toEqual(jasmine.objectContaining({ bar: 2 }));

--- a/src/transformers/__testfixtures__/chai-chain/instanceof.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/instanceof.input.js
@@ -1,0 +1,1 @@
+expect(foo).to.be.an.instanceof(Foo);

--- a/src/transformers/__testfixtures__/chai-chain/instanceof.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/instanceof.output.js
@@ -1,0 +1,1 @@
+expect(foo).toEqual(jasmine.any(Foo));

--- a/src/transformers/__testfixtures__/chai-chain/keys.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/keys.input.js
@@ -1,0 +1,5 @@
+expect([1, 2, 3]).to.have.all.keys(1, 2);
+expect([1, 2, 3]).to.have.any.keys([1, 2]);
+expect({ foo: 1, bar: 2 }).to.have.all.keys({ bar: 6, foo: 7 });
+expect({ foo: 1, bar: 2, baz: 3 }).to.contain.all.keys(['bar', 'foo']);
+expect({ foo: 1, bar: 2, baz: 3 }).to.contain.all.keys({ bar: 6 });

--- a/src/transformers/__testfixtures__/chai-chain/keys.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/keys.output.js
@@ -1,0 +1,5 @@
+expect([1, 2, 3]).toEqual(jasmine.arrayContaining([1, 2]));
+expect([1, 2, 3]).toEqual(jasmine.arrayContaining([1, 2]));
+expect(Object.keys({ foo: 1, bar: 2 })).toEqual(jasmine.arrayContaining(Object.keys({ bar: 6, foo: 7 })));
+expect(Object.keys({ foo: 1, bar: 2, baz: 3 })).toEqual(jasmine.arrayContaining(['bar', 'foo']));
+expect(Object.keys({ foo: 1, bar: 2, baz: 3 })).toEqual(jasmine.arrayContaining(Object.keys({ bar: 6 })));

--- a/src/transformers/__testfixtures__/chai-chain/least.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/least.input.js
@@ -1,0 +1,1 @@
+expect(10).to.be.at.least(10);

--- a/src/transformers/__testfixtures__/chai-chain/least.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/least.output.js
@@ -1,0 +1,1 @@
+expect(10).toBeGreaterThanOrEqual(10);

--- a/src/transformers/__testfixtures__/chai-chain/lengthof.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/lengthof.input.js
@@ -1,0 +1,2 @@
+expect([1, 2, 3]).to.have.lengthOf(3);
+expect('foobar').to.have.lengthOf(6);

--- a/src/transformers/__testfixtures__/chai-chain/lengthof.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/lengthof.output.js
@@ -1,0 +1,2 @@
+expect([1, 2, 3].length).toBe(3);
+expect('foobar'.length).toBe(6);

--- a/src/transformers/__testfixtures__/chai-chain/match.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/match.input.js
@@ -1,0 +1,1 @@
+expect('foobar').to.match(/^foo/);

--- a/src/transformers/__testfixtures__/chai-chain/match.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/match.output.js
@@ -1,0 +1,1 @@
+expect('foobar').toMatch(/^foo/);

--- a/src/transformers/__testfixtures__/chai-chain/members.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/members.input.js
@@ -1,0 +1,7 @@
+expect([1, 2, 3]).to.include.members([3, 2]);
+expect([1, 2, 3]).to.not.include.members([3, 2, 8]);
+
+expect([4, 2]).to.have.members([2, 4]);
+expect([5, 2]).to.not.have.members([5, 2, 1]);
+
+expect([{ id: 1 }]).to.deep.include.members([{ id: 1 }]);

--- a/src/transformers/__testfixtures__/chai-chain/members.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/members.output.js
@@ -1,0 +1,7 @@
+expect([1, 2, 3]).toEqual(jasmine.arrayContaining([3, 2]));
+expect([1, 2, 3]).not.toEqual(jasmine.arrayContaining([3, 2, 8]));
+
+expect([4, 2]).toEqual(jasmine.arrayContaining([2, 4]));
+expect([5, 2]).not.toEqual(jasmine.arrayContaining([5, 2, 1]));
+
+expect([{ id: 1 }]).toEqual(jasmine.arrayContaining([{ id: 1 }]));

--- a/src/transformers/__testfixtures__/chai-chain/most.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/most.input.js
@@ -1,0 +1,1 @@
+expect(5).to.be.at.most(5);

--- a/src/transformers/__testfixtures__/chai-chain/most.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/most.output.js
@@ -1,0 +1,1 @@
+expect(5).toBeLessThanOrEqual(5);

--- a/src/transformers/__testfixtures__/chai-chain/nan.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/nan.input.js
@@ -1,0 +1,2 @@
+expect('foo').to.be.NaN;
+expect(4).not.to.be.NaN;

--- a/src/transformers/__testfixtures__/chai-chain/nan.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/nan.output.js
@@ -1,0 +1,2 @@
+expect('foo').toBeNaN();
+expect(4).not.toBeNaN();

--- a/src/transformers/__testfixtures__/chai-chain/null.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/null.input.js
@@ -1,0 +1,2 @@
+expect(null).to.be.null;
+expect(undefined).to.not.be.null;

--- a/src/transformers/__testfixtures__/chai-chain/null.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/null.output.js
@@ -1,0 +1,2 @@
+expect(null).toBeNull();
+expect(undefined).not.toBeNull();

--- a/src/transformers/__testfixtures__/chai-chain/ok.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/ok.input.js
@@ -1,0 +1,5 @@
+expect('everything').to.be.ok;
+expect(1).to.be.ok;
+expect(false).to.not.be.ok;
+expect(undefined).to.not.be.ok;
+expect(null).to.not.be.ok;

--- a/src/transformers/__testfixtures__/chai-chain/ok.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/ok.output.js
@@ -1,0 +1,5 @@
+expect('everything').toBeTruthy();
+expect(1).toBeTruthy();
+expect(false).toBeFalsy();
+expect(undefined).toBeFalsy();
+expect(null).toBeFalsy();

--- a/src/transformers/__testfixtures__/chai-chain/ownproperty.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/ownproperty.input.js
@@ -1,0 +1,1 @@
+expect('test').to.have.ownProperty('length');

--- a/src/transformers/__testfixtures__/chai-chain/ownproperty.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/ownproperty.output.js
@@ -1,0 +1,1 @@
+expect('test'.hasOwnProperty('length')).toBeTruthy();

--- a/src/transformers/__testfixtures__/chai-chain/ownpropertydescriptor.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/ownpropertydescriptor.input.js
@@ -1,0 +1,3 @@
+expect('test').to.have.ownPropertyDescriptor('length');
+expect('test').to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
+expect('test').not.to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 3 });

--- a/src/transformers/__testfixtures__/chai-chain/ownpropertydescriptor.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/ownpropertydescriptor.output.js
@@ -1,0 +1,3 @@
+expect(Object.getOwnPropertyDescriptor('test', 'length')).not.toBeUndefined();
+expect(Object.getOwnPropertyDescriptor('test', 'length')).toEqual({ enumerable: false, configurable: false, writable: false, value: 4 });
+expect(Object.getOwnPropertyDescriptor('test', 'length')).toEqual({ enumerable: false, configurable: false, writable: false, value: 3 });

--- a/src/transformers/__testfixtures__/chai-chain/throw.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/throw.input.js
@@ -1,0 +1,8 @@
+const err = new ReferenceError('This is a bad function.');
+const fn = function() { throw err; };
+expect(fn).to.throw(ReferenceError);
+expect(fn).to.throw(Error);
+expect(fn).to.throw(/bad function/);
+expect(fn).to.not.throw('good function');
+expect(fn).to.throw(ReferenceError, /bad function/);
+expect(fn).to.throw(err);

--- a/src/transformers/__testfixtures__/chai-chain/throw.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/throw.output.js
@@ -1,0 +1,8 @@
+const err = new ReferenceError('This is a bad function.');
+const fn = function() { throw err; };
+expect(fn).toThrowError(ReferenceError);
+expect(fn).toThrowError(Error);
+expect(fn).toThrowError(/bad function/);
+expect(fn).not.toThrowError('good function');
+expect(fn).toThrowError(ReferenceError, /bad function/);
+expect(fn).toThrowError(err);

--- a/src/transformers/__testfixtures__/chai-chain/true.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/true.input.js
@@ -1,0 +1,2 @@
+expect(true).to.be.true;
+expect(1).to.not.be.true;

--- a/src/transformers/__testfixtures__/chai-chain/true.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/true.output.js
@@ -1,0 +1,2 @@
+expect(true).toBe(true);
+expect(1).not.toBe(true);

--- a/src/transformers/__testfixtures__/chai-chain/undefined.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/undefined.input.js
@@ -1,0 +1,2 @@
+expect(undefined).to.be.undefined;
+expect(null).to.not.be.undefined;

--- a/src/transformers/__testfixtures__/chai-chain/undefined.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/undefined.output.js
@@ -1,0 +1,2 @@
+expect(undefined).toBeUndefined();
+expect(null).toBeDefined();

--- a/src/transformers/__testfixtures__/chai-chain/within.input.js
+++ b/src/transformers/__testfixtures__/chai-chain/within.input.js
@@ -1,0 +1,4 @@
+expect(7).to.be.within(5, 10);
+
+expect('foo').to.have.length.within(2, 4);
+expect([1, 2, 3]).to.have.length.within(2, 4);

--- a/src/transformers/__testfixtures__/chai-chain/within.output.js
+++ b/src/transformers/__testfixtures__/chai-chain/within.output.js
@@ -1,0 +1,8 @@
+expect(7).toBeLessThanOrEqual(5);
+expect(7).toBeGreaterThanOrEqual(10);
+
+expect('foo'.length).toBeLessThanOrEqual(2);
+
+expect('foo'.length).toBeGreaterThanOrEqual(4);
+expect([1, 2, 3].length).toBeLessThanOrEqual(2);
+expect([1, 2, 3].length).toBeGreaterThanOrEqual(4);

--- a/src/transformers/chai-chain.js
+++ b/src/transformers/chai-chain.js
@@ -1,0 +1,270 @@
+const path = require('path');
+const parser = require('babel-eslint');
+const util = require('./util');
+// not implemented respondTo
+// modifications, oneOf, change, increase, decrease - statement modification
+
+const fns = ['keys', 'a', 'an', 'instanceof', 'lengthof', 'length', 'equal', 'throw', 'include',
+    'contain', 'eql', 'above', 'least', 'below', 'most', 'match', 'string',
+    'members', 'property', 'ownproperty', 'ownpropertydescriptor', 'gte', 'lte', 'within'];
+
+const members = ['ok', 'true', 'false', 'null', 'undefined', 'exist', 'empty', 'nan', 'defined'];
+
+module.exports = function transformer(file, api) {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+    let mutations = 0;
+
+    const createCall = util.createCall(j);
+    const chainContains = util.chainContains(j);
+    const getAllBefore = util.getNodeBeforeMemberExpression(j);
+    const updateExpect = util.updateExpect(j);
+    const createCallChain = util.createCallChain(j);
+
+    const isExpectCall = node => (node.name === 'expect' ||
+  (node.type === j.MemberExpression.name &&
+  isExpectCall(node.object)) ||
+  (node.type === j.CallExpression.name &&
+  isExpectCall(node.callee)));
+
+    const typeOf = (value, args, containsNot) => {
+        switch (args[0].value) {
+            case 'null':
+                return createCall('toBeNull', [], updateExpect(value, node => node, containsNot));
+            case 'undefined':
+                return createCall('toBeUndefined', [], updateExpect(value, node => node, containsNot));
+            default:
+                return createCall('toBe', args,
+          updateExpect(value, node => j.unaryExpression('typeof', node)), containsNot);
+        }
+    };
+
+    const isPrefix = name => (['to', 'with', 'that'].indexOf(name) !== -1);
+
+    function parseArgs(args) {
+        if (args.length === 1 && args[0].type === j.ObjectExpression.name) {
+            return [createCallChain(['Object', 'keys'], args)];
+        } else if (args.length > 1) {
+            return [j.arrayExpression(args)];
+        }
+
+        return args;
+    }
+
+    function containing(node) {
+        switch (node.type) {
+            case j.ArrayExpression.name:
+                return createCallChain(['jasmine', 'arrayContaining'], [node]);
+            case j.ObjectExpression.name:
+                return createCallChain(['jasmine', 'objectContaining'], [node]);
+            default:
+                return node;
+        }
+    }
+
+    function withIn(p, rest, args, containsNot) {
+        if (args.length !== 2) {
+            console.warn(`.withIn needs two arguments, you passed ${args.length}`);
+            return p;
+        }
+
+        const containsLength = chainContains('length', p.value.callee, isPrefix);
+        const expect = () => (containsLength ?
+      updateExpect(rest, node => j.memberExpression(node, j.identifier('length'))) :
+      rest);
+
+        j(p).closest(j.ExpressionStatement).insertBefore(
+      j.expressionStatement(
+        createCall('toBeLessThanOrEqual', [args[0]], expect(), containsNot)));
+
+        return createCall('toBeGreaterThanOrEqual', [args[1]], expect(), containsNot);
+    }
+
+    const shouldToExpect = () =>
+    root.find(j.MemberExpression, {
+        property: {
+            type: j.Identifier.name,
+            name: 'should',
+        },
+    })
+      .replaceWith(p => j.callExpression(j.identifier('expect'), [p.node.object]))
+      .size();
+
+    const updateMemberExpressions = () =>
+    root.find(j.MemberExpression, {
+        property: {
+            name: name => members.indexOf(name.toLowerCase()) !== -1,
+        },
+    }).replaceWith(p => {
+        const { value } = p;
+        const rest = getAllBefore(isPrefix, value, 'should');
+        const containsNot = chainContains('not', value, 'to');
+
+        switch (value.property.name.toLowerCase()) {
+            case 'ok':
+                return containsNot ?
+            createCall('toBeFalsy', [], rest) :
+            createCall('toBeTruthy', [], rest);
+            case 'true':
+                return createCall('toBe', [j.booleanLiteral(true)], rest, containsNot);
+            case 'false':
+                return createCall('toBe', [j.booleanLiteral(false)], rest, containsNot);
+            case 'null':
+                return createCall('toBeNull', [], rest, containsNot);
+            case 'nan':
+                return createCall('toBeNaN', [], rest, containsNot);
+            case 'undefined':
+                return containsNot ?
+            createCall('toBeDefined', [], rest) :
+            createCall('toBeUndefined', [], rest);
+            case 'empty':
+            case 'exist':
+            case 'defined':
+                return containsNot ?
+            createCall('toBeFalsy', [], rest) :
+            createCall('toBeDefined', [], rest);
+            default:
+                return value;
+        }
+    })
+      .size();
+
+    const updateCallExpressions = () =>
+    root.find(j.CallExpression, {
+        callee: {
+            type: j.MemberExpression.name,
+            property: {
+                name: name => fns.indexOf(name.toLowerCase()) !== -1,
+            },
+            object: isExpectCall,
+        },
+    })
+      .replaceWith(p => {
+          const { value } = p;
+          const rest = getAllBefore(isPrefix, value.callee, 'should');
+          const containsNot = chainContains('not', value.callee, isPrefix);
+          const containsDeep = chainContains('deep', value.callee, isPrefix);
+          const containsAny = chainContains('any', value.callee, isPrefix);
+          const args = value.arguments;
+
+          switch (p.value.callee.property.name.toLowerCase()) {
+              case 'equal':
+                  return containsDeep ? createCall('toEqual', args, rest, containsNot) :
+              createCall('toBe', args, rest, containsNot);
+              case 'throw':
+                  return createCall('toThrowError', args, rest, containsNot);
+              case 'include':
+              case 'string':
+              case 'contain':
+                  if (args.length === 1 && args[0].type === j.ObjectExpression.name) {
+                      return createCall('toEqual', [containing(args[0])], rest, containsNot);
+                  }
+                  return createCall('toContain', args, rest, containsNot);
+              case 'eql':
+                  return createCall('toEqual', args, rest, containsNot);
+              case 'above':
+                  return createCall('toBeGreaterThan', args, rest, containsNot);
+              case 'least':
+              case 'gte':
+                  return createCall('toBeGreaterThanOrEqual', args, rest, containsNot);
+              case 'below':
+                  return createCall('toBeLessThan', args, rest, containsNot);
+              case 'most':
+              case 'lte':
+                  return createCall('toBeLessThanOrEqual', args, rest, containsNot);
+              case 'within':
+                  return withIn(p, rest, args, containsNot);
+              case 'match':
+                  return createCall('toMatch', args, rest, containsNot);
+              case 'members':
+                  return createCall('toEqual', args.map(containing), rest, containsNot);
+              case 'keys':
+                  if (containsAny) {
+                      const relativePath = path.relative(process.cwd(), file.path);
+                      console.warn(`any.keys is an unsupported keyword, please check ${relativePath}`);
+                  }
+                  return createCall('toEqual',
+              [createCallChain(['jasmine', 'arrayContaining'], parseArgs(args))],
+              updateExpect(value, node => {
+                  if (node.type === j.ObjectExpression.name) {
+                      return createCallChain(['Object', 'keys'], [node]);
+                  }
+                  return node;
+              }), containsNot);
+              case 'a':
+              case 'an':
+                  if (!args.length) {
+                      return value;
+                  }
+                  if (args[0].type === j.StringLiteral.name) {
+                      return typeOf(value, args, containsNot);
+                  }
+                  return createCall('toBe', [j.booleanLiteral(true)],
+              updateExpect(value, node => j.binaryExpression('instanceof', node, args[0])),
+              containsNot
+            );
+              case 'instanceof':
+                  return createCall('toEqual', [createCallChain(['jasmine', 'any'], [args[0]])],
+              rest,
+              containsNot
+            );
+              case 'length':
+              case 'lengthof':
+                  return createCall('toBe', args,
+              updateExpect(value, node => j.memberExpression(node, j.identifier('length'))),
+              containsNot
+            );
+              case 'property':
+                  if (containsDeep) {
+                      const relativePath = path.relative(process.cwd(), file.path);
+                      console.warn(`deep.property is an unsupported keyword, please check ${relativePath}`);
+                  }
+                  return args.length === 1 ?
+              createCall('toBeTruthy', [],
+                updateExpect(value, node => j.callExpression(
+                  j.memberExpression(node, j.identifier('hasOwnProperty')),
+                  [args[0]]
+                ))
+              ) :
+              createCall('toEqual', [args[1]],
+                updateExpect(value, node => j.memberExpression(
+                  node, args[0], true
+                ))
+              );
+              case 'ownproperty':
+                  return createCall('toBeTruthy', [],
+              updateExpect(value, node => j.callExpression(
+                j.memberExpression(node, j.identifier('hasOwnProperty')),
+                [args[0]]
+              ))
+            );
+              case 'ownpropertydescriptor':
+                  return args.length === 1 ?
+              createCall('toBeUndefined', [],
+                updateExpect(value, node => j.callExpression(
+                  j.memberExpression(
+                    j.identifier('Object'), j.identifier('getOwnPropertyDescriptor')),
+                  [node, args[0]]
+                )), true
+              ) :
+              createCall('toEqual', [args[1]],
+                updateExpect(value, node => j.callExpression(
+                  j.memberExpression(
+                    j.identifier('Object'), j.identifier('getOwnPropertyDescriptor')),
+                  [node, args[0]]
+                ))
+              );
+              default:
+                  return value;
+          }
+      })
+      .size();
+
+    mutations += shouldToExpect();
+    mutations += updateCallExpressions();
+    mutations += updateMemberExpressions();
+
+    return mutations ? root.toSource({ parser, quote: 'single' }) : null;
+};
+
+module.exports.parser = 'babylon';

--- a/src/transformers/chai-chain.test.js
+++ b/src/transformers/chai-chain.test.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+const transformersPath = path.join(__dirname, 'transformers');
+
+const createTest = name => {
+    defineTest(transformersPath, 'chai-chain', null, path.join('chai-chain', name));
+};
+
+defineTest(transformersPath, 'chai-chain', null, 'chai-chain');
+
+createTest('a-an');
+createTest('above');
+createTest('below');
+createTest('eql');
+createTest('equal');
+createTest('exist-defined');
+createTest('false');
+createTest('include-contain');
+createTest('instanceof');
+createTest('keys');
+createTest('least');
+createTest('lengthof');
+createTest('match');
+createTest('members');
+createTest('most');
+createTest('nan');
+createTest('null');
+createTest('ok');
+createTest('ownproperty');
+createTest('ownpropertydescriptor');
+createTest('throw');
+createTest('true');
+createTest('undefined');
+createTest('within');

--- a/src/transformers/util/chainContains.js
+++ b/src/transformers/util/chainContains.js
@@ -1,0 +1,12 @@
+module.exports = j => (fnName, node, end) => {
+    let curr = node;
+    const checkEnd = (typeof end === 'function') ? end : name => name === end;
+
+    while (curr.type === j.MemberExpression.name
+  && curr.property.name !== fnName
+  && !checkEnd(curr.property.name)) {
+        curr = curr.object;
+    }
+
+    return curr.type === j.MemberExpression.name && curr.property.name === fnName;
+};

--- a/src/transformers/util/createCall.js
+++ b/src/transformers/util/createCall.js
@@ -1,0 +1,10 @@
+module.exports = j => (fnName, args, rest, containsNot) => {
+    const expression = containsNot ? j.memberExpression(rest, j.identifier('not')) : rest;
+
+    return j.memberExpression(
+    expression,
+    j.callExpression(
+      j.identifier(fnName),
+      args
+    ));
+};

--- a/src/transformers/util/createCallChain.js
+++ b/src/transformers/util/createCallChain.js
@@ -1,0 +1,15 @@
+module.exports = j => (chain, args) => {
+    const arr = chain.reverse();
+
+    let val = arr.pop();
+    let temp = (typeof val === 'string') ? j.identifier(val) : val;
+    let curr = temp;
+
+    while (chain.length) {
+        val = arr.pop();
+        temp = (typeof val === 'string') ? j.identifier(val) : val;
+        curr = j.memberExpression(curr, temp);
+    }
+
+    return j.callExpression(curr, args);
+};

--- a/src/transformers/util/getNodeBeforeMemberExpression.js
+++ b/src/transformers/util/getNodeBeforeMemberExpression.js
@@ -1,0 +1,21 @@
+module.exports = j => (memberName, node, end) => {
+    let rest = node;
+    const equalsMemberName = (typeof memberName === 'function') ? memberName : (name => name === memberName);
+    const equalsEnd = (typeof end === 'function') ? end : name => name === end;
+
+    while (rest.type === j.MemberExpression.name
+    && !equalsMemberName(rest.property.name)
+    && !equalsEnd(rest.property.name)
+  ) {
+        rest = rest.object;
+    }
+
+    if (rest.type === j.MemberExpression.name
+    && equalsMemberName(rest.property.name)
+    && !equalsEnd(rest.property.name)
+  ) {
+        rest = rest.object;
+    }
+
+    return rest;
+};

--- a/src/transformers/util/index.js
+++ b/src/transformers/util/index.js
@@ -1,0 +1,14 @@
+const createCall = require('./createCall');
+const chainContains = require('./chainContains');
+const getNodeBeforeMemberExpression = require('./getNodeBeforeMemberExpression');
+const updateExpect = require('./updateExpect');
+const createCallChain = require('./createCallChain');
+
+
+module.exports = {
+    createCall,
+    chainContains,
+    getNodeBeforeMemberExpression,
+    updateExpect,
+    createCallChain,
+};

--- a/src/transformers/util/updateExpect.js
+++ b/src/transformers/util/updateExpect.js
@@ -1,0 +1,26 @@
+module.exports = j => (node, fn) => {
+    const getExpectNode = n => {
+        let curr = n;
+
+        while (curr.type === j.MemberExpression.name ||
+    (curr.type === j.CallExpression.name && curr.callee.name !== 'expect')) {
+            if (curr.type === j.MemberExpression.name) {
+                curr = curr.object;
+            } else if (curr.type === j.CallExpression.name) {
+                curr = curr.callee;
+            }
+        }
+
+        return curr;
+    };
+
+    const expectNode = getExpectNode(node);
+
+    if (expectNode == null || expectNode.arguments == null) {
+        return node;
+    }
+
+    const args = expectNode.arguments.map(fn);
+
+    return j.callExpression(j.identifier('expect'), args);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,11 +6,7 @@ abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
-abbrev@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
-
-abbrev@1.0.x:
+abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
@@ -316,6 +312,15 @@ babel-core@^6.0.0, babel-core@^6.11.4, babel-core@^6.24.0:
     private "^0.1.6"
     slash "^1.0.0"
     source-map "^0.5.0"
+
+babel-eslint@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.1.tgz#079422eb73ba811e3ca0865ce87af29327f8c52f"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.16.1"
 
 babel-generator@^6.18.0, babel-generator@^6.24.0:
   version "6.24.0"
@@ -981,7 +986,7 @@ babylon@^5.8.38:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.8.1:
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.16.1, babylon@^6.8.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 


### PR DESCRIPTION
Imported chai should expect transform from https://github.com/AlexJuarez/chai-to-jasmine.

Tests Added
- created __testfixtures__ folder and added input/output files for chai-chain and functionality.

Dependencies Added
- babel-eslint (for correctly preserving white-space.)