### PR TITLE
Prevent the codeshift changing call expressions to functions defined in scope

### DIFF
--- a/src/transformers/mocha.test.js
+++ b/src/transformers/mocha.test.js
@@ -124,3 +124,22 @@ describe.skip('skip suite', () => {
 });
 `
 );
+
+testChanged('preserves call expressions that are defined in scope',
+`
+const setup = () => {};
+context('test suite', () => {
+    it('test', () => {
+        const foo = setup();
+    });
+});
+`,
+`
+const setup = () => {};
+describe('test suite', () => {
+    it('test', () => {
+        const foo = setup();
+    });
+});
+`
+);


### PR DESCRIPTION
The mocha codeshift was changing all call expressions that matched the methodMap to the jest equivalent without any regard for the function potentially being defined in the file.

To fix, we check if the call expression has a binding in the file and if so skip renaming it.