### PR TITLE
Should.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Codemods that simplify migrating JavaScript test files from
 [Mocha](https://github.com/mochajs/mocha),
 [Chai](https://github.com/chaijs/chai),
+[Should.js](https://github.com/tj/should.js/),
 [proxyquire](https://github.com/thlorenz/proxyquire),
 [Tape](https://github.com/substack/tape)
 and [AVA](https://github.com/avajs/ava)
@@ -80,6 +81,7 @@ $ jscodeshift -t node_modules/jest-codemods/dist/transformers/ava.js test-folder
 $ jscodeshift -t node_modules/jest-codemods/dist/transformers/chai-assert.js test-folder
 $ jscodeshift -t node_modules/jest-codemods/dist/transformers/chai-should.js test-folder
 $ jscodeshift -t node_modules/jest-codemods/dist/transformers/mocha.js test-folder
+$ jscodeshift -t node_modules/jest-codemods/dist/transformers/should.js test-folder
 $ jscodeshift -t node_modules/jest-codemods/dist/transformers/tape.js test-folder
 ```
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -39,11 +39,13 @@ const TRANSFORMER_AVA = 'ava';
 const TRANSFORMER_CHAI_ASSERT = 'chai-assert';
 const TRANSFORMER_CHAI_SHOULD = 'chai-should';
 const TRANSFORMER_MOCHA = 'mocha';
+const TRANSFORMER_SHOULD = 'should';
 const TRANSFORMER_TAPE = 'tape';
+
 const ALL_TRANSFORMERS = [
     TRANSFORMER_AVA,
     TRANSFORMER_CHAI_ASSERT,
-    // TRANSFORMER_CHAI_SHOULD doesn't have import detection
+    // TRANSFORMER_CHAI_SHOULD & TRANSFORMER_SHOULD doesn't have import detection
     TRANSFORMER_MOCHA,
     TRANSFORMER_TAPE,
 ];
@@ -79,6 +81,10 @@ inquirer
                     value: TRANSFORMER_MOCHA,
                 },
                 {
+                    name: 'Should.js',
+                    value: TRANSFORMER_SHOULD,
+                },
+                {
                     name: 'Tape',
                     value: TRANSFORMER_TAPE,
                 },
@@ -94,8 +100,8 @@ inquirer
         },
         {
             type: 'list',
-            name: 'mochaChai',
-            message: 'Would you like to include Chai transformations with Mocha?',
+            name: 'mochaAssertion',
+            message: 'Would you like to include assertion transformations with Mocha?',
             when: ({ transformer }) => TRANSFORMER_MOCHA === transformer,
             choices: [
                 {
@@ -105,6 +111,10 @@ inquirer
                 {
                     name: 'Should/Expect BDD Syntax',
                     value: TRANSFORMER_CHAI_SHOULD,
+                },
+                {
+                    name: 'Should.js',
+                    value: TRANSFORMER_SHOULD,
                 },
                 {
                     name: 'None',
@@ -122,7 +132,7 @@ inquirer
         },
     ])
     .then(answers => {
-        const { files, transformer, mochaChai } = answers;
+        const { files, transformer, mochaAssertion } = answers;
 
         if (transformer === 'other') {
             return supportFailure('AVA, Tape, Chai and Mocha');
@@ -130,8 +140,8 @@ inquirer
 
         const transformers = transformer === 'all' ? ALL_TRANSFORMERS : [transformer];
 
-        if (mochaChai) {
-            transformers.push(mochaChai);
+        if (mochaAssertion) {
+            transformers.push(mochaAssertion);
         }
 
         const filesExpanded = cli.input.length ? cli.input : globby.sync(files);

--- a/src/transformers/chai-should.test.js
+++ b/src/transformers/chai-should.test.js
@@ -621,3 +621,6 @@ it('leaves code without should/expect', () => {
 
     expect(result).toBeNull();
 });
+
+// TODO: warn about chaining not working
+// E.g. expect({ foo: 'baz' }).to.have.property('foo').and.not.equal('bar');

--- a/src/transformers/should.js
+++ b/src/transformers/should.js
@@ -1,0 +1,90 @@
+import { removeRequireAndImport } from '../utils/imports';
+import { traverseMemberExpressionUtil } from '../utils/recast-helpers';
+import detectQuoteStyle from '../utils/quote-style';
+
+import chaiShouldTransformer from './chai-should';
+
+const assertionRemappings = {
+    throws: 'throw',
+};
+
+module.exports = function transformer(fileInfo, api) {
+    const j = api.jscodeshift;
+    const root = j(fileInfo.source);
+
+    const isShouldMemberExpression = traverseMemberExpressionUtil(
+        j,
+        node =>
+            (node.type === j.CallExpression.name && node.callee.name === 'should') ||
+            (node.type === j.Identifier.name && node.name === 'should')
+    );
+
+    /**
+     * Injects missing to prefixes expected by chai-should transformer.
+     * TODO: not sure if this is even required for chai...
+     */
+    function injectMissingPrefix() {
+        const injector = p => {
+            const { property } = p.parentPath.value;
+            if (property && property.type === j.Identifier.name) {
+                if (property.name !== 'to') {
+                    const newPath = j.memberExpression(p.value, j.identifier('to'));
+                    p.replace(newPath);
+                }
+            }
+        };
+
+        root
+            .find(j.CallExpression, {
+                callee: {
+                    name: name => ['expect', 'should'].indexOf(name) >= 0,
+                },
+            })
+            .forEach(injector);
+
+        root
+            .find(j.MemberExpression, {
+                property: {
+                    type: j.Identifier.name,
+                    name: 'should',
+                },
+            })
+            .forEach(injector);
+    }
+
+    function renameShouldCallExpressions() {
+        root
+            .find(j.CallExpression, {
+                callee: {
+                    name: 'should',
+                },
+            })
+            .forEach(p => {
+                p.value.callee.name = 'expect';
+            });
+    }
+
+    function remapAssertions() {
+        root
+            .find(j.MemberExpression, {
+                property: {
+                    name: name => Object.keys(assertionRemappings).indexOf(name) >= 0,
+                },
+            })
+            .filter(p => isShouldMemberExpression(p.value))
+            .forEach(p => {
+                const { property } = p.value;
+                property.name = assertionRemappings[property.name];
+            });
+    }
+
+    removeRequireAndImport(j, root, 'should');
+    injectMissingPrefix();
+    renameShouldCallExpressions();
+    remapAssertions();
+
+    const quote = detectQuoteStyle(j, root) || 'single';
+    fileInfo.source = root.toSource({ quote });
+
+    return chaiShouldTransformer(fileInfo, api);
+};

--- a/src/transformers/should.test.js
+++ b/src/transformers/should.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+import chalk from 'chalk';
+import { wrapPlugin } from '../utils/test-helpers';
+import plugin from './should';
+
+chalk.enabled = false;
+
+const wrappedPlugin = wrapPlugin(plugin);
+let consoleWarnings = [];
+beforeEach(() => {
+    consoleWarnings = [];
+    console.warn = v => consoleWarnings.push(v);
+});
+
+function testChanged(msg, source, expectedOutput) {
+    test(msg, () => {
+        const result = wrappedPlugin(source);
+        expect(result).toBe(expectedOutput);
+        expect(consoleWarnings).toEqual([]);
+    });
+}
+
+testChanged(
+    'removes imports and does basic conversions of should.js',
+    `
+        var should = require('should');
+
+        var user = {
+            name: 'tj'
+          , pets: ['tobi', 'loki', 'jane', 'bandit']
+        };
+
+        user.should.have.property('name', 'tj');
+        should(user).have.property('name', 'tj');
+        should(true).ok;
+        should.throws(foo, /^Description/);
+        should(foo).be.undefined();
+    `,
+    `
+        var user = {
+            name: 'tj'
+          , pets: ['tobi', 'loki', 'jane', 'bandit']
+        };
+
+        expect(user).toHaveProperty('name', 'tj');
+        expect(user).toHaveProperty('name', 'tj');
+        expect(true).toBeTruthy();
+        expect(foo).toThrowError(/^Description/);
+        expect(foo).toBeUndefined();
+    `
+);
+
+testChanged(
+    'leaves code without should/expect',
+    `
+        function test() {
+            i.have.a.dream();
+            i.have.a.dream;
+        }
+        `,
+    null
+);

--- a/src/utils/recast-helpers.js
+++ b/src/utils/recast-helpers.js
@@ -30,3 +30,19 @@ export function getMemberExpressionElements(node, _rest = []) {
     }
     return getMemberExpressionElements(node.object, [node.property.name].concat(_rest));
 }
+
+export function traverseMemberExpressionUtil(j, nodeValidator) {
+    const traverseMemberExpression = node => {
+        if (!node) {
+            return false;
+        }
+
+        if (nodeValidator(node)) {
+            return true;
+        }
+
+        return traverseMemberExpression(node.object);
+    };
+
+    return traverseMemberExpression;
+}


### PR DESCRIPTION
Recently Chai should (https://github.com/chaijs/chai) transformation was added. The semantics is very close to should.js (https://github.com/tj/should.js/), so we can make official support for transforming should.js assertions to Jest.

Work in progress.

See #49, #47. Closes #51.