### PR TITLE
Transform AVA's snapshot assertion

### DIFF
--- a/src/transformers/ava.js
+++ b/src/transformers/ava.js
@@ -42,6 +42,7 @@ const tPropertiesMap = {
     ifError: 'toBeFalsy',
     error: 'toBeFalsy',
     plan: SPECIAL_PLAN_CASE,
+    snapshot: 'toMatchSnapshot',
 };
 
 const tPropertiesNotMapped = new Set(['end', 'fail', 'pass']);

--- a/src/transformers/ava.test.js
+++ b/src/transformers/ava.test.js
@@ -69,6 +69,7 @@ test('mapping', (t) => {
   t.ifError(abc)
   t.error(abc)
   t.plan(3)
+  t.snapshot(abc)
 })
 `,
     `
@@ -97,6 +98,7 @@ test('mapping', () => {
   expect(abc).toBeFalsy()
   expect(abc).toBeFalsy()
   expect.assertions(3)
+  expect(abc).toMatchSnapshot()
 });
 `
 );


### PR DESCRIPTION
AVA supports [Snapshot testing](https://github.com/avajs/ava#snapshot-testing). It uses `jest-snapshot` under the hood, so the migration should be seamless.