### PR TITLE
Graphql js improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --fix",
-      "git add"
+      "eslint"
     ]
   },
   "keywords": [

--- a/src/transformers/chai-should.js
+++ b/src/transformers/chai-should.js
@@ -84,9 +84,11 @@ module.exports = function transformer(fileInfo, api, options) {
     const updateExpect = updateExpectUtil(j);
     const createCallChain = createCallChainUtil(j);
 
-    removeRequireAndImport(j, root, 'chai', 'expect');
-    removeRequireAndImport(j, root, 'chai', 'should');
-    // Not sure if expect is always imported... So we continue with the transformation:
+    const chaiExpectRemoved = removeRequireAndImport(j, root, 'chai', 'expect');
+    const chaiShouldRemoved = removeRequireAndImport(j, root, 'chai', 'should');
+    if (chaiExpectRemoved || chaiShouldRemoved) {
+        mutations += 1;
+    }
 
     const isExpectCall = node =>
         node.name === 'expect' ||

--- a/src/transformers/chai-should.js
+++ b/src/transformers/chai-should.js
@@ -135,6 +135,13 @@ module.exports = function transformer(fileInfo, api, options) {
                         )
                     )
                 );
+            case 'error':
+                return createCall(
+                    'toBeInstanceOf',
+                    [j.identifier('Error')],
+                    updateExpect(value, node => node),
+                    containsNot
+                );
             default:
                 return createCall(
                     'toBe',

--- a/src/transformers/chai-should.test.js
+++ b/src/transformers/chai-should.test.js
@@ -94,7 +94,7 @@ testChanged(
         expect('xyz').toBeInstanceOf(String);
         expect(null).toBeNull();
         expect(undefined).toBeUndefined();
-        expect(typeof new Error()).toBe('error');
+        expect(new Error()).toBeInstanceOf(Error);
         expect(typeof new Promise()).toBe('promise');
         expect(typeof new Float32Array()).toBe('float32array');
         expect(typeof Symbol()).toBe('symbol');

--- a/src/transformers/mocha.js
+++ b/src/transformers/mocha.js
@@ -1,3 +1,4 @@
+import { removeRequireAndImport } from '../utils/imports';
 import finale from '../utils/finale';
 import jasmineThisTransformer from './jasmine-this';
 
@@ -37,6 +38,8 @@ function hasBinding(name, scope) {
 export default function mochaToJest(fileInfo, api, options) {
     const j = api.jscodeshift;
     const ast = j(fileInfo.source);
+
+    removeRequireAndImport(j, ast, 'mocha');
 
     Object.keys(methodMap).forEach(mochaMethod => {
         const jestMethod = methodMap[mochaMethod];

--- a/src/transformers/mocha.test.js
+++ b/src/transformers/mocha.test.js
@@ -149,3 +149,16 @@ describe('test suite', () => {
 });
 `
 );
+
+testChanged(
+    'removes mocha import',
+    `
+import { describe, it } from 'mocha';
+suite('suite', () => {
+})
+    `,
+    `
+describe('suite', () => {
+})
+    `
+);


### PR DESCRIPTION
I like to test out `jest-codemods` on new projects. As I'm a GraphQL fanboy, I tried migrating https://github.com/graphql/graphql-js from Mocha to Jest. 

Only around 5% of the test are failing... But found a few smaller issues with `jest-codemods` that could be improved (**which is what this PR contains**).

### Challenges if `graphql-js` want to move to Jest:
- Jest compares Errors to and Error (Mocha seems to convert it to string and objects)
- usage of `chai-subset` cannot be converted to `toMatchObject` as the latter does not match as loose in children (might be worth a PR)
- JSON equal is used a lot of places*

*) Could be solved with:
```javascript
const diff = require('jest-diff');

function jsonify(x) {
  return JSON.parse(JSON.stringify(x));
}

expect.extend({
  jsonEqual(receivedInput, expectedInput) {
    const received = jsonify(receivedInput);
    const expected = jsonify(expectedInput);
    const pass = this.equals(received, expected);

    const message = pass ?
      () =>
        this.utils.matcherHint('.not.toBe') +
        '\n\n' +
        'Expected value to not be (using JSON representation):\n' +
        `  ${this.utils.printExpected(expected)}\n` +
        'Received:\n' +
        `  ${this.utils.printReceived(received)}` :
      () => {
        const diffString = diff(expected, received, {
          expand: this.expand,
        });
        return (
          this.utils.matcherHint('.toBe') +
          '\n\n' +
          'Expected value to be (using JSON representation):\n' +
          `  ${this.utils.printExpected(expected)}\n` +
          'Received:\n' +
          `  ${this.utils.printReceived(received)}` +
          (diffString ? `\n\nDifference:\n\n${diffString}` : '')
        );
      };

    return { actual: received, message, pass };
  },
});

```