### PR TITLE
Detect line terminator from input

### DIFF
--- a/src/transformers/should.js
+++ b/src/transformers/should.js
@@ -1,6 +1,7 @@
 import { removeRequireAndImport } from '../utils/imports';
 import { traverseMemberExpressionUtil } from '../utils/recast-helpers';
 import detectQuoteStyle from '../utils/quote-style';
+import detectLineTerminator from '../utils/line-terminator';
 
 import chaiShouldTransformer from './chai-should';
 
@@ -84,7 +85,8 @@ module.exports = function transformer(fileInfo, api, options) {
     remapAssertions();
 
     const quote = detectQuoteStyle(j, root) || 'single';
-    fileInfo.source = root.toSource({ quote });
+    const lineTerminator = detectLineTerminator(fileInfo.source);
+    fileInfo.source = root.toSource({ quote, lineTerminator });
 
     return chaiShouldTransformer(fileInfo, api, options);
 };

--- a/src/utils/finale.js
+++ b/src/utils/finale.js
@@ -3,6 +3,7 @@ import { addRequireOrImportOnceFactory, hasRequireOrImport } from './imports';
 import logger from './logger';
 import proxyquireTransformer from './proxyquire';
 import detectQuoteStyle from './quote-style';
+import detectLineTerminator from './line-terminator';
 
 function detectIncompatiblePackages(fileInfo, j, ast) {
     ['sinon', 'testdouble'].forEach(pkg => {
@@ -53,5 +54,6 @@ export default function finale(fileInfo, j, ast, transformerOptions, testFunctio
     // As Recast is not preserving original quoting, we try to detect it,
     // and default to something sane.
     const quote = detectQuoteStyle(j, ast) || 'single';
-    return ast.toSource({ quote });
+    const lineTerminator = detectLineTerminator(fileInfo.source);
+    return ast.toSource({ quote, lineTerminator });
 }

--- a/src/utils/imports.test.js
+++ b/src/utils/imports.test.js
@@ -9,6 +9,8 @@ import {
 
 const j = jscodeshift;
 
+const getOptions = () => ({ lineTerminator: '\n' });
+
 describe('removeRequireAndImport', () => {
     it('removes require statements', () => {
         const ast = j(
@@ -19,7 +21,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'foo');
         expect(removedVariableName).toBe('x');
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             x();
         `
@@ -35,7 +37,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'foo');
         expect(removedVariableName).toBeNull();
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             console.log('yes');
         `
@@ -51,7 +53,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'foo');
         expect(removedVariableName).toBe('x');
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             x();
         `
@@ -67,7 +69,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'foo', 'bar');
         expect(removedVariableName).toBe('x');
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             x();
         `
@@ -84,7 +86,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'foo', 'bop');
         expect(removedVariableName).toBeNull();
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             const x = require('foo').bar;
             require('foo').baz();
@@ -102,7 +104,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'baz');
         expect(removedVariableName).toBe('xx');
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             xx();
         `
@@ -118,7 +120,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'baz');
         expect(removedVariableName).toBeNull();
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             console.log('yes');
         `
@@ -134,7 +136,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'baz', 'xx');
         expect(removedVariableName).toBe('xx');
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             xx();
         `
@@ -150,7 +152,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'baz', 'xx');
         expect(removedVariableName).toBe('foo');
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             xx();
         `
@@ -166,7 +168,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'baz', 'yy');
         expect(removedVariableName).toBeNull();
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             import { xx } from 'baz';
             xx();
@@ -185,7 +187,7 @@ describe('removeRequireAndImport', () => {
         );
         const removedVariableName = removeRequireAndImport(j, ast, 'baz');
         expect(removedVariableName).toBe('xx');
-        expect(ast.toSource()).toEqual(
+        expect(ast.toSource(getOptions())).toEqual(
             `
             // @flow
             /* eslint... */
@@ -204,7 +206,7 @@ describe('removeRequireAndImport', () => {
         const ast = j(inputSource);
         const removedVariableName = removeRequireAndImport(j, ast, 'foo');
         expect(removedVariableName).toBe(null);
-        expect(ast.toSource()).toEqual(inputSource);
+        expect(ast.toSource(getOptions())).toEqual(inputSource);
     });
 });
 

--- a/src/utils/line-terminator.js
+++ b/src/utils/line-terminator.js
@@ -1,0 +1,10 @@
+/**
+ * By default, Recast uses the line terminator of the OS the code runs on.
+ * This is often not desired, so we instead try to detect it from the input.
+ * If there is at least one Windows-style linebreak (CRLF) in the input, use that.
+ * In all other cases, use Unix-style (LF).
+ * @return '\n' or '\r\n'
+ */
+export default function detectLineTerminator(source) {
+    return source && source.includes('\r\n') ? '\r\n' : '\n';
+}

--- a/src/utils/proxyquire.test.js
+++ b/src/utils/proxyquire.test.js
@@ -8,6 +8,8 @@ jest.mock('./logger', () => () => mockedLogger(...arguments));
 const j = jscodeshift;
 const fileInfo = { path: 'a.test.js' };
 
+const getOptions = () => ({ quote: 'single', lineTerminator: '\n' });
+
 it('rewrites proxyquire without noCallThru', () => {
     const ast = j(
         `
@@ -19,7 +21,7 @@ it('rewrites proxyquire without noCallThru', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         jest.mock('./features/baz', () => () => <div />);
         jest.mock('common/Foo', () => () => <div />);
@@ -39,7 +41,7 @@ it('rewrites proxyquire with noCallThru', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         jest.mock('common/Foo', () => () => <div />);
         const Page = require('./PageContainer');
@@ -58,7 +60,7 @@ it('rewrites proxyquire with require statement noCallThru', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         jest.mock('lib', () => () => {});
         const tracking = require('./tracking');
@@ -88,7 +90,7 @@ it('supports variable reference object', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         import sinon from 'sinon';
 
@@ -120,7 +122,7 @@ it('supports empty noCallThru', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         jest.mock('b', () => 'c');
         const a = require('a');
@@ -137,7 +139,7 @@ it('supports the `load` method', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         jest.mock('b', () => 'c');
         const a = require('a');
@@ -154,7 +156,7 @@ it('supports a chained `noCallThru().load()` call', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         jest.mock('b', () => 'c');
         const a = require('a');
@@ -173,7 +175,7 @@ it('logs error when proxyquire mocks are not defined in the file', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         import mockedDeps from './someFile';
         proxyquire.noCallThru()('./index', mockedDeps);
@@ -206,7 +208,7 @@ it('logs error with multiple proxyquire to same file', () => {
     `
     );
     proxyquireTransformer(fileInfo, j, ast);
-    expect(ast.toSource({ quote: 'single' })).toEqual(
+    expect(ast.toSource(getOptions())).toEqual(
         `
         jest.mock('../page', () => mockedRender);
         const routeHandler = require('./handler');


### PR DESCRIPTION
Nearly all tests are failing on Windows because Recast by default changes all line endings to those of the current OS, but the tests are using Unix-style LF.

This PR makes tests pass on Windows and also uses LF on any input files that don't contain any CRLF linebreaks.

Feel free to tweak the detection logic.