### PR TITLE
tape: deepEquals is the same as deepEqual

### DIFF
--- a/src/transformers/tape.js
+++ b/src/transformers/tape.js
@@ -45,6 +45,7 @@ const tPropertiesMap = {
     isInequal: 'not.toBe',
 
     deepEqual: 'toEqual',
+    deepEquals: 'toEqual',
     isEquivalent: 'toEqual',
     same: 'toEqual',
 

--- a/src/transformers/tape.js
+++ b/src/transformers/tape.js
@@ -36,6 +36,7 @@ const tPropertiesMap = {
     strictEquals: 'toBe',
 
     notEqual: 'not.toBe',
+    notEquals: 'not.toBe',
     notStrictEqual: 'not.toBe',
     notStrictEquals: 'not.toBe',
     isNotEqual: 'not.toBe',
@@ -54,6 +55,7 @@ const tPropertiesMap = {
     notDeeply: 'not.toEqual',
     notSame: 'not.toEqual',
     isNotDeepEqual: 'not.toEqual',
+    isNotDeeply: 'not.toEqual',
     isNotEquivalent: 'not.toEqual',
     isInequivalent: 'not.toEqual',
 

--- a/src/transformers/tape.test.js
+++ b/src/transformers/tape.test.js
@@ -93,6 +93,7 @@ test((t) => {
     t.isInequal(1, 2, 'msg');
 
     t.deepEqual(app.x, {foo: 2}, 'msg');
+    t.deepEquals(app.x, {foo: 2}, 'msg');
     t.isEquivalent(1, 2, 'msg');
     t.same(1, 2, 'msg');
 
@@ -143,6 +144,7 @@ test(done => {
     expect(1).not.toBe(2);
     expect(1).not.toBe(2);
 
+    expect(app.x).toEqual({foo: 2});
     expect(app.x).toEqual({foo: 2});
     expect(1).toEqual(2);
     expect(1).toEqual(2);

--- a/src/transformers/tape.test.js
+++ b/src/transformers/tape.test.js
@@ -83,6 +83,7 @@ test((t) => {
     t.strictEquals(1, 2, 'msg');
 
     t.notEqual(1, 2, 'msg');
+    t.notEquals(1, 2, 'msg');
     t.notStrictEqual(1, 2, 'msg');
     t.notStrictEquals(1, 2, 'msg');
     t.isNotEqual(1, 2, 'msg');
@@ -102,6 +103,7 @@ test((t) => {
     t.notDeeply(1, 2, 'msg');
     t.notSame(1, 2, 'msg');
     t.isNotDeepEqual(1, 2, 'msg');
+    t.isNotDeeply(1, 2, 'msg');
     t.isNotEquivalent(1, 2, 'msg');
     t.isInequivalent(1, 2, 'msg');
 
@@ -140,6 +142,7 @@ test(done => {
     expect(1).not.toBe(2);
     expect(1).not.toBe(2);
     expect(1).not.toBe(2);
+    expect(1).not.toBe(2);
 
     expect(1).not.toBe(2);
     expect(1).not.toBe(2);
@@ -149,6 +152,7 @@ test(done => {
     expect(1).toEqual(2);
     expect(1).toEqual(2);
 
+    expect(1).not.toEqual(2);
     expect(1).not.toEqual(2);
     expect(1).not.toEqual(2);
     expect(1).not.toEqual(2);


### PR DESCRIPTION
I'm not totally sure of this, but it was one of the things that wasn't switched in our codebase.

Maybe it supports lots of endings with `s`?