### PR TITLE
Add Node 8 LTS to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '8'
   - '6'
   - '4'
 script:


### PR DESCRIPTION
Node 8 is the new LTS, this PR adds testing on Node 8 to travis configuration.