### PR TITLE
Add failing test for a bad codemod: .has.property().to.be.an()

### DIFF
--- a/src/transformers/chai-should.test.js
+++ b/src/transformers/chai-should.test.js
@@ -86,6 +86,7 @@ testChanged(
         expect(baz).to.not.be.an('array');
 
         'test'.should.be.a('string');
+        expect({objectProperty: {}}).to.have.property('objectProperty').to.be.an('object');
     `,
     `
         expect(typeof 'test').toBe('string');
@@ -104,6 +105,7 @@ testChanged(
         expect(Array.isArray(baz)).toBe(false);
 
         expect(typeof 'test').toBe('string');
+        expect({objectProperty: {}}).toMatchObject({objectProperty: expect.any(Object)});
     `
 );
 


### PR DESCRIPTION
This PR adds a failing test exposing the issue in #91 and proposes a better translation.