### PR TITLE
fix chai.approximately and chai.closeTo transformer

### DIFF
--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -253,9 +253,18 @@ export default function transformer(fileInfo, api, options) {
             .find(j.CallExpression, getAssertionExpression(assertion))
             .replaceWith(path =>
                 makeExpectation(
-                    'toBeCloseTo',
-                    path.value.arguments[0],
-                    path.value.arguments.slice(1, 3)
+                    'toBeLessThanOrEqual',
+                    j.callExpression(
+                        j.memberExpression(j.identifier('Math'), j.identifier('abs')),
+                        [
+                            j.binaryExpression(
+                                '-',
+                                path.value.arguments[0],
+                                path.value.arguments[1]
+                            ),
+                        ]
+                    ),
+                    [path.value.arguments[2]]
                 )
             );
     });

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -111,8 +111,14 @@ const mappings = [
     ['assert.lengthOf(foo, bar, baz);', 'expect(foo.length).toBe(bar);'],
     ['assert.throws(foo, bar, baz);', 'expect(foo).toThrow();'],
     ['assert.doesNotThrow(foo, bar, baz);', 'expect(foo).not.toThrow();'],
-    ['assert.closeTo(foo, bar, baz, msg);', 'expect(foo).toBeCloseTo(bar, baz);'],
-    ['assert.approximately(foo, bar, baz);', 'expect(foo).toBeCloseTo(bar, baz);'],
+    [
+        'assert.closeTo(foo, bar, baz, msg);',
+        'expect(Math.abs(foo - bar)).toBeLessThanOrEqual(baz);',
+    ],
+    [
+        'assert.approximately(foo, bar, baz);',
+        'expect(Math.abs(foo - bar)).toBeLessThanOrEqual(baz);',
+    ],
     ['assert.sameMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
     ['assert.sameDeepMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
     ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],


### PR DESCRIPTION
Fixes #93.

It wasn't correct to map these assertions directly to Jest's 'toBeCloseTo()',
because Jest defines "closeness" in terms of number of significant digits
and Chai expects a delta. To make the conversion correct, I'm
calculating the absolute difference between actual and expected, and
asserting that it's less than the delta.