### PR TITLE
support chai default import in chai-assert transformer

### DIFF
--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -195,3 +195,29 @@ assert.${assertion}(foo, bar, baz);`,
         'jest-codemods warning: (test.js line 15) Unsupported Chai Assertion "ifError".',
     ]);
 });
+
+testChanged(
+    'applies when chai default import used',
+    `
+// @flow
+import chai from 'chai';
+chai.assert.equal(foo, bar, baz);
+`,
+    `
+// @flow
+expect(foo).toEqual(bar);
+`
+);
+
+testChanged(
+    'transforms renamed imports',
+    `
+// @flow
+import { assert as myCoolAssert } from 'chai';
+myCoolAssert.equal(foo, bar, baz);
+`,
+    `
+// @flow
+expect(foo).toEqual(bar);
+`
+);

--- a/src/utils/imports.js
+++ b/src/utils/imports.js
@@ -91,6 +91,28 @@ export function getRequireOrImportName(j, ast, pkg) {
 }
 
 /**
+ * Detects and removes default import statements for given package.
+ * @return the local name for the default import or null
+ */
+export function removeDefaultImport(j, ast, pkg) {
+    const getBodyNode = () => ast.find(j.Program).get('body', 0).node;
+    const { comments } = getBodyNode(j, ast);
+
+    let localName = null;
+    findImports(j, ast, pkg).forEach(p => {
+        const pathSpecifier = p.value.specifiers[0];
+        if (pathSpecifier && pathSpecifier.type === 'ImportDefaultSpecifier') {
+            localName = pathSpecifier.local.name;
+            p.prune();
+        }
+    });
+
+    getBodyNode(j, ast).comments = comments;
+
+    return localName;
+}
+
+/**
  * Detects and removes CommonJS and import statements for given package.
  * @return the import variable name or null if no import were found.
  */


### PR DESCRIPTION
Fixes #94.

I'm removing any default imports from chai, and (if any were found) replacing all `chai.assert`s using all the existing chai-assert transformations. E.g.
```javascript
import chai from 'chai';

chai.assert.equal(1, 1);
```

becomes
```javascript
expect(1).toEqual(1);
```

While refactoring this code, I've also added support for cases where the assert import is renamed. E.g. 
```javascript
import { assert as myAssert } from 'chai';
myAssert.equal(1, 1);
```