### PR TITLE
Move Prettier options to .prettierrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,10 +8,7 @@ module.exports = {
     },
     root: true,
     rules: {
-        'prettier/prettier': [
-            'error',
-            { trailingComma: 'es5', singleQuote: true, printWidth: 90, tabWidth: 4 },
-        ],
+        'prettier/prettier': 'error',
 
         'import/order': [
             'error',

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "printWidth": 90,
+    "tabWidth": 4
+}


### PR DESCRIPTION
Resolves #111

`npm run lint` still passes for me locally after this change.

To further illustrate that this works, if I modify a Prettier option:

```diff
diff --git a/.prettierrc b/.prettierrc
index 59ca7b2..34537a6 100644
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
     "trailingComma": "es5",
-    "singleQuote": true,
+    "singleQuote": false,
     "printWidth": 90,
     "tabWidth": 4
 }
```

`npm run lint` will fix all of the quotemarks to be double quotes:

```
## use-prettierrc...origin/use-prettierrc
 M .prettierrc
 M src/cli/git-status.js
 M src/cli/git-status.test.js
 M src/cli/index.js
 M src/cli/transformers.js
 M src/cli/transformers.test.js
 M src/transformers/ava.js
 M src/transformers/ava.test.js
 M src/transformers/chai-assert.js
 M src/transformers/chai-assert.test.js
 M src/transformers/chai-should.js
 M src/transformers/chai-should.test.js
 M src/transformers/expect-js.js
 M src/transformers/expect-js.test.js
 M src/transformers/expect.js
 M src/transformers/expect.test.js
 M src/transformers/jasmine-this.js
 M src/transformers/jasmine-this.test.js
 M src/transformers/mocha.js
 M src/transformers/mocha.test.js
 M src/transformers/should.js
 M src/transformers/should.test.js
 M src/transformers/tape.js
 M src/transformers/tape.test.js
 M src/utils/chai-chain-utils.js
 M src/utils/consts.js
 M src/utils/finale.js
 M src/utils/finale.test.js
 M src/utils/imports.js
 M src/utils/imports.test.js
 M src/utils/line-terminator.js
 M src/utils/logger.js
 M src/utils/proxyquire.js
 M src/utils/proxyquire.test.js
 M src/utils/quote-style.js
 M src/utils/quote-style.test.js
 M src/utils/recast-helpers.js
 M src/utils/tape-ava-helpers.js
 M src/utils/test-helpers.js
```