### PR TITLE
Fix Tape codemod for t.doesNotThrow(fn, expected, msg)

### DIFF
--- a/src/transformers/tape.js
+++ b/src/transformers/tape.js
@@ -176,7 +176,11 @@ export default function tapeToJest(fileInfo, api, options) {
                             );
                         } else {
                             newCondition = j.callExpression(
-                                j.identifier('toThrowError'),
+                                j.identifier(
+                                    oldPropertyName === 'throws'
+                                        ? 'toThrowError'
+                                        : 'not.toThrowError'
+                                ),
                                 [args[1]]
                             );
                         }

--- a/src/transformers/tape.test.js
+++ b/src/transformers/tape.test.js
@@ -489,3 +489,18 @@ foo(() => {});
 test(() => {});
 `
 );
+
+testChanged(
+    'doesNotThrow works with `expected` argument',
+    `
+import test from 'tape';
+test('foo', t => {
+    t.doesNotThrow(() => {}, TypeError, 'foo');
+});
+`,
+    `
+test('foo', () => {
+    expect(() => {}).not.toThrowError(TypeError);
+});
+`
+);


### PR DESCRIPTION
Expected behavior:

`t.doesNotThrow(fn, expected, msg)` should transpile to `expect(fn).not.toThrowError(expected)`

Actual behavior:

`t.doesNotThrow(fn, expected, msg)` transpiles to `expect(fn).toThrowError(expected)`

Solution:

This PR fixes the codemod so that it outputs the expected code.