### PR TITLE
Add support for jscodeshift's --ignore-pattern CLI option

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,15 +18,17 @@ const cli = meow(
     path    Files or directory to transform. Can be a glob like src/**.test.js
 
     Options
-      --force, -f   Bypass Git safety checks and forcibly run codemods
-      --dry, -d     Dry run (no changes are made to files)
-      --parser      The parser to use for parsing your source files (babel | babylon | flow)  [babel]
+      --ignore-pattern, -i  Ignore files that match a provided glob expression
+      --force, -f           Bypass Git safety checks and forcibly run codemods
+      --dry, -d             Dry run (no changes are made to files)
+      --parser              The parser to use for parsing your source files (babel | babylon | flow)  [babel]
     `,
     },
     {
         boolean: ['force', 'dry'],
         string: ['_'],
         alias: {
+            i: 'ignorePattern',
             f: 'force',
             h: 'help',
             d: 'dry',

--- a/src/cli/transformers.js
+++ b/src/cli/transformers.js
@@ -8,9 +8,15 @@ function executeTransformation(files, flags, transformer, transformerArgs) {
     const transformerPath = path.join(transformerDirectory, `${transformer}.js`);
 
     let args = ['-t', transformerPath].concat(files);
+
     if (flags.dry) {
         args.push('--dry');
     }
+
+    if (flags.ignorePattern) {
+        args.push('--ignore-pattern', flags.ignorePattern);
+    }
+
     if (['babel', 'babylon', 'flow'].indexOf(flags.parser) >= 0) {
         args.push('--parser', flags.parser);
     }

--- a/src/cli/transformers.test.js
+++ b/src/cli/transformers.test.js
@@ -36,12 +36,16 @@ it('runs jscodeshift for the given transformer', () => {
 it('supports jscodeshift flags', () => {
     execaReturnValue = { error: null };
     console.log = jest.fn();
-    executeTransformations('folder', { dry: true, parser: 'flow' }, ['ava']);
+    executeTransformations(
+        'folder',
+        { dry: true, ignorePattern: '/node_modules/', parser: 'flow' },
+        ['ava']
+    );
     expect(console.log).toBeCalledWith(
         `Executing command: jscodeshift -t ${path.join(
             transformerDirectory,
             'ava.js'
-        )} folder --dry --parser flow`
+        )} folder --dry --ignore-pattern /node_modules/ --parser flow`
     );
 });
 


### PR DESCRIPTION
Passing through `--ignore-pattern` CLI option to jscodeshift.