### PR TITLE
jasmine globals

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -45,6 +45,7 @@ const TRANSFORMER_CHAI_ASSERT = 'chai-assert';
 const TRANSFORMER_CHAI_SHOULD = 'chai-should';
 const TRANSFORMER_EXPECT_JS = 'expect-js';
 const TRANSFORMER_EXPECT_1 = 'expect';
+const TRANSFORMER_JASMINE_GLOBALS = 'jasmine-globals';
 const TRANSFORMER_JASMINE_THIS = 'jasmine-this';
 const TRANSFORMER_MOCHA = 'mocha';
 const TRANSFORMER_SHOULD = 'should';
@@ -81,6 +82,10 @@ const TRANSFORMER_INQUIRER_CHOICES = [
     {
         name: 'Expect@1.x (by mjackson)',
         value: TRANSFORMER_EXPECT_1,
+    },
+    {
+        name: 'Jasmine: globals',
+        value: TRANSFORMER_JASMINE_GLOBALS,
     },
     {
         name: 'Jasmine: this usage',

--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -11,6 +11,30 @@ export default function jasmineGlobals(fileInfo, api, options) {
     const emptyArrowFn = j('() => {}').__paths[0].value.program.body[0].expression;
 
     root
+        // find all `jasmine.createSpy('stuff')
+        .find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                property: {
+                    type: 'Identifier',
+                    name: 'createSpy',
+                },
+                object: {
+                    type: 'Identifier',
+                    name: 'jasmine',
+                },
+            },
+        })
+        .forEach(path => {
+            // make it `jest.fn()`
+            path.node.callee = j.memberExpression(
+                j.identifier('jest'),
+                j.identifier('fn')
+            );
+            path.node.arguments = [];
+        });
+
+    root
         // find all global `spyOn` calls that are standalone expressions.
         // e.g.
         // spyOn(stuff)

--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -1,0 +1,127 @@
+/**
+ * Codemod for transforming Jasmine `this` context into Jest v20+ compatible syntax.
+ */
+
+import finale from '../utils/finale';
+
+export default function jasmineGlobals(fileInfo, api, options) {
+    const j = api.jscodeshift;
+    const root = j(fileInfo.source);
+
+    const emptyArrowFn = j('() => {}').__paths[0].value.program.body[0].expression;
+
+    root
+        // find all global `spyOn` calls that are standalone expressions.
+        // e.g.
+        // spyOn(stuff)
+        // but not
+        // spyOn(stuff).and.callThrough();
+        .find(j.ExpressionStatement, {
+            expression: {
+                type: 'CallExpression',
+                callee: {
+                    type: 'Identifier',
+                    name: 'spyOn',
+                },
+            },
+        })
+        .forEach(path => {
+            path.node.expression = j.callExpression(
+                j.memberExpression(
+                    path.node.expression,
+                    // add .mockImplementation(() => {}); call
+                    // because jasmine spy's default is to mock the return value,
+                    // whereas jest calls through by default.
+                    j.identifier('mockImplementation')
+                ),
+                [emptyArrowFn]
+            );
+        });
+
+    root
+        // find spyOn().and.*() expressions
+        .find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                object: {
+                    type: 'MemberExpression',
+                    property: { name: 'and' },
+                    object: {
+                        type: 'CallExpression',
+                        callee: {
+                            type: 'Identifier',
+                            name: 'spyOn',
+                        },
+                    },
+                },
+            },
+        })
+        .forEach(path => {
+            const spyType = path.node.callee.property.name;
+            switch (spyType) {
+                // if it's `spyOn().and.callThrough()`
+                // we should remove it and make just `spyOn()`
+                // because jest calls through by default
+                case 'callThrough': {
+                    const callee = path.node.callee.object.object.callee;
+                    const arg = path.node.callee.object.object.arguments;
+                    path.node.callee = callee;
+                    path.node.arguments = arg;
+                    break;
+                }
+                // if it's `spyOn().and.callFake()` replace with jest's
+                // equivalent `spyOn().mockImplementation();
+                case 'callFake': {
+                    path.node.callee.object = path.node.callee.object.object;
+                    path.node.callee.property.name = 'mockImplementation';
+                    break;
+                }
+                // `spyOn().and.returnValue()` is equivalent of
+                // `jest.spyOn().mockReturnValue()`
+                case 'returnValue': {
+                    path.node.callee.object = path.node.callee.object.object;
+                    path.node.callee.property.name = 'mockReturnValue';
+                    break;
+                }
+            }
+        });
+
+    root
+        //   find all `SpyOn` calls
+        .find(j.CallExpression, {
+            callee: { type: 'Identifier', name: 'spyOn' },
+        })
+        .forEach(path => {
+            // and make them `jest.spyOn()`
+            path.node.callee = j.memberExpression(
+                j.identifier('jest'),
+                j.identifier('spyOn')
+            );
+        });
+
+    root
+        // find all `*.calls.count()`
+        .find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                property: { type: 'Identifier', name: 'count' },
+                object: {
+                    type: 'MemberExpression',
+                    property: { type: 'Identifier', name: 'calls' },
+                },
+            },
+        })
+        .forEach(path => {
+            // replace `.count()` with `.length`
+            path.node.callee.property.name = 'length';
+            // add extra `.mock` property that jest uses:
+            //   stuff.calls.count() -> stuff.mock.calls.length
+            path.node.callee.object.object = j.memberExpression(
+                path.node.callee.object.object,
+                j.identifier('mock')
+            );
+            j(path).replaceWith(path.node.callee);
+        });
+
+    return finale(fileInfo, j, root, options);
+}

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -23,6 +23,8 @@ testChanged(
     jest.spyOn();
     spyOn(stuff);
     jest.spyOn().mockImplementation();
+    jasmine.createSpy();
+    jasmine.createSpy('lmao');
     `,
     `
     jest.spyOn().mockReturnValue();
@@ -32,6 +34,8 @@ testChanged(
     jest.spyOn();
     jest.spyOn(stuff).mockImplementation(() => {});
     jest.spyOn().mockImplementation();
+    jest.fn();
+    jest.fn();
     `
 );
 

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+import chalk from 'chalk';
+import { wrapPlugin } from '../utils/test-helpers';
+import plugin from './jasmine-globals';
+
+chalk.enabled = false;
+const wrappedPlugin = wrapPlugin(plugin);
+
+function testChanged(msg, source, expectedOutput) {
+    test(msg, () => {
+        const result = wrappedPlugin(source);
+        expect(result).toBe(expectedOutput);
+    });
+}
+
+testChanged(
+    'spyOn',
+    `
+    jest.spyOn().mockReturnValue();
+    spyOn(stuff).and.callThrough();
+    spyOn(stuff).and.callFake(() => 'lol');
+    spyOn(stuff).and.returnValue('lmao');
+    jest.spyOn();
+    spyOn(stuff);
+    jest.spyOn().mockImplementation();
+    `,
+    `
+    jest.spyOn().mockReturnValue();
+    jest.spyOn(stuff);
+    jest.spyOn(stuff).mockImplementation(() => 'lol');
+    jest.spyOn(stuff).mockReturnValue('lmao');
+    jest.spyOn();
+    jest.spyOn(stuff).mockImplementation(() => {});
+    jest.spyOn().mockImplementation();
+    `
+);
+
+testChanged(
+    'mock.calls.count()',
+    `
+    someMock.calls.count();
+    stuff.someMock.calls.count();
+    getMock(stuff).calls.count();
+    getMock(stuff).calls.count() > 1;
+    `,
+    `
+    someMock.mock.calls.length;
+    stuff.someMock.mock.calls.length;
+    getMock(stuff).mock.calls.length;
+    getMock(stuff).mock.calls.length > 1;
+    `
+);

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -46,11 +46,33 @@ testChanged(
     stuff.someMock.calls.count();
     getMock(stuff).calls.count();
     getMock(stuff).calls.count() > 1;
+    wyoming.cheyenne.callCount
+    wyoming.cheyenne.stuff.mostRecentCall.args[0]
+    georgia.atlanta.mostRecentCall.args.map(fn)
+    args.map()
+    oklahoma.argsForCall[0]
+    idaho.argsForCall[0][1]
+    spyOn('stuff').andCallFake(fn);
+    hmm.andCallFake(fn);
+    spyOn('stuff').andReturn('lol');
+    spyOn('stuff').andCallThrough();
+    stuff.andCallThrough();
     `,
     `
     someMock.mock.calls.length;
     stuff.someMock.mock.calls.length;
     getMock(stuff).mock.calls.length;
     getMock(stuff).mock.calls.length > 1;
+    wyoming.cheyenne.mock.calls.length
+    wyoming.cheyenne.stuff.mock.calls[wyoming.cheyenne.stuff.mock.calls.length - 1][0]
+    georgia.atlanta.mock.calls[georgia.atlanta.mock.calls.length - 1].map(fn)
+    args.map()
+    oklahoma.mock.calls[0]
+    idaho.mock.calls[0][1]
+    jest.spyOn('stuff').mockImplementation(fn);
+    hmm.mockImplementation(fn);
+    jest.spyOn('stuff').mockReturnValue('lol');
+    jest.spyOn('stuff');
+    stuff;
     `
 );


### PR DESCRIPTION
we're migrating from using `jasmine` to using `jest-circus` and i'm writing some codemods that'll simplify the migration.
this is not going to be perfect, because there's a lot of state that's impossible to track through AST, but hopefully it can get us closer to the full migration