### PR TITLE
fix: Proxyquire matches wrong CallExpression

### DIFF
--- a/src/utils/proxyquire.test.js
+++ b/src/utils/proxyquire.test.js
@@ -165,6 +165,27 @@ it('supports a chained `noCallThru().load()` call', () => {
     expect(mockedLogger).not.toBeCalled();
 });
 
+it('supports named imports scoped to the variable name', () => {
+    const ast = j(
+        `
+        import pq from 'proxyquire';
+        beforeEach( function(){
+            const something = pq( 'a', {'b': 'c'});
+        });
+    `
+    );
+    proxyquireTransformer(fileInfo, j, ast);
+    expect(ast.toSource(getOptions())).toEqual(
+        `
+        jest.mock('b', () => 'c');
+        beforeEach( function(){
+            const something = require('a');
+        });
+    `
+    );
+    expect(mockedLogger).not.toBeCalled();
+});
+
 it('logs error when proxyquire mocks are not defined in the file', () => {
     // TODO: this is kind of a bad state, but also a funny usage of proxyquire
     const ast = j(


### PR DESCRIPTION
Hey! Love this project thanks for all the efforts.

This change fixes the mechanism that finds Proxyquire instances. Before this change it was not finding the correct CallExpression. After this change, it precisely finds any CallExpression where the callee's name is the provided identifier.

Here's some sample code that led me to this pull request:
```js
beforeEach( function(){
	const something = pq( '../../../../some/file', {
		'some-key' : {
			SomeClass : spies.someSpy
		}
	});
});
```

Before this change, it was trying to identify `beforeEach` as the "outer call expression" when it should be targeting `pq()`. With this change the codemod was able to accurately replace these instances.

Cheers!