### PR TITLE
Avoid error from a function in an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 dist
 .vscode/
 yarn-error.log
+.idea/

--- a/src/transformers/jasmine-this.js
+++ b/src/transformers/jasmine-this.js
@@ -19,6 +19,7 @@ function isFunctionExpressionWithinSpecificFunctions(path, acceptedFunctionNames
     return (
         !!callExpressionPath &&
         !!callExpressionPath.value &&
+        callExpressionPath.value.callee &&
         callExpressionPath.value.callee.type === 'Identifier' &&
         acceptedFunctionNames.indexOf(callExpressionPath.value.callee.name) > -1
     );

--- a/src/transformers/jasmine-this.test.js
+++ b/src/transformers/jasmine-this.test.js
@@ -390,3 +390,29 @@ describe('foo', () => {
 });
 `
 );
+
+testChanged(
+    'ignores a function in an array',
+    `
+describe('foo', function() {
+    it('should tolerate an array of functions', function() {
+        foo.apply(model, [
+            function() {
+                bar();
+            }
+        ]);
+    });
+});
+`,
+    `
+describe('foo', () => {
+    it('should tolerate an array of functions', () => {
+        foo.apply(model, [
+            function() {
+                bar();
+            }
+        ]);
+    });
+});
+`
+);


### PR DESCRIPTION
Avoid TypeError: Cannot read property 'type' of undefined by checking for callee before evaluating callee.type
[https://github.com/skovhus/jest-codemods/issues/135]