### PR TITLE
Retain generator functions

### DIFF
--- a/src/transformers/jasmine-this.js
+++ b/src/transformers/jasmine-this.js
@@ -200,6 +200,7 @@ export default function jasmineThis(fileInfo, api, options) {
             .filter(path =>
                 isFunctionExpressionWithinSpecificFunctions(path, allFunctionNames)
             )
+            .filter(path => !path.value.generator)
             .replaceWith(path => {
                 const newFn = j.arrowFunctionExpression(
                     path.value.params,

--- a/src/transformers/jasmine-this.test.js
+++ b/src/transformers/jasmine-this.test.js
@@ -52,6 +52,44 @@ describe('foo', () => {
 );
 
 testChanged(
+    'does not transform generator functions',
+    `
+describe('foo', function*() {
+    beforeEach(function*() {
+        this.foo = { id: 'FOO' };
+        this.bar = { id: 'BAR', child: this.foo };
+    });
+
+    it('should have proper IDs', function*() {
+        expect(this.foo.id).to.equal('FOO');
+        expect(this.bar.id).to.equal('BAR');
+        expect(this.bar.child.id).to.equal('FOO');
+    });
+});
+`,
+    `
+describe('foo', function*() {
+    let testContext;
+
+    beforeEach(() => {
+        testContext = {};
+    });
+
+    beforeEach(function*() {
+        testContext.foo = { id: 'FOO' };
+        testContext.bar = { id: 'BAR', child: testContext.foo };
+    });
+
+    it('should have proper IDs', function*() {
+        expect(testContext.foo.id).to.equal('FOO');
+        expect(testContext.bar.id).to.equal('BAR');
+        expect(testContext.bar.child.id).to.equal('FOO');
+    });
+});
+`
+);
+
+testChanged(
     'transforms only test functions context',
     `
 describe('foo', function() {


### PR DESCRIPTION
Firstly, thanks heaps for making and maintaining these codemods! They have been super helpful to us while me migrate our legacy tests to Jest. 🙂

## Description

Our legacy Mocha tests use generator functions (async/await was barely an idea back then 😅) and the `jasmine-this.js` codemod, which is used in the `mocha.js` codemod, currently replaces all test callbacks with arrow functions. While this is almost always desirable behaviour, arrow functions have no generator equivalent. I added a small change to omit generator function nodes from the list of functions to convert and thought it might be useful to you. No worries if it isn't.