### PR TITLE
Reject "ok" when it isn't proceeded by "to"

### DIFF
--- a/src/transformers/chai-should.js
+++ b/src/transformers/chai-should.js
@@ -351,7 +351,7 @@ module.exports = function transformer(fileInfo, api, options) {
                     const { value } = p;
                     const propertyName = value.property.name.toLowerCase();
 
-                    // Reject "ok" when it isn't not preceeded by "to"
+                    // Reject "ok" when it isn't  proceeded by "to"
                     return !(propertyName === 'ok' && !chainContains('to', value, 'to'));
                 });
 

--- a/src/transformers/chai-should.js
+++ b/src/transformers/chai-should.js
@@ -346,7 +346,14 @@ module.exports = function transformer(fileInfo, api, options) {
                         name: name => members.indexOf(name.toLowerCase()) !== -1,
                     },
                 })
-                .filter(p => findParentOfType(p, 'ExpressionStatement'));
+                .filter(p => findParentOfType(p, 'ExpressionStatement'))
+                .filter(p => {
+                    const { value } = p;
+                    const propertyName = value.property.name.toLowerCase();
+
+                    // Reject "ok" when it isn't not preceeded by "to"
+                    return !(propertyName === 'ok' && !chainContains('to', value, 'to'));
+                });
 
         getMembers().forEach(p => {
             if (p.parentPath.value.type === j.CallExpression.name) {

--- a/src/transformers/chai-should.test.js
+++ b/src/transformers/chai-should.test.js
@@ -518,7 +518,11 @@ testChanged(
         expect(undefined).to.not.be.ok;
         expect(null).to.not.be.ok;
         expect(null).to.not.be.ok();
-    `,
+
+        const x = { ok: true };
+        expect(x.ok).toBeTruthy();
+        assert.ok(x.ok);
+        `,
     `
         expect('everything').toBeTruthy();
         expect(1).toBeTruthy();
@@ -526,7 +530,11 @@ testChanged(
         expect(undefined).toBeFalsy();
         expect(null).toBeFalsy();
         expect(null).toBeFalsy();
-    `
+
+        const x = { ok: true };
+        expect(x.ok).toBeTruthy();
+        assert.ok(x.ok);
+        `
 );
 
 testChanged(

--- a/src/transformers/chai-should.test.js
+++ b/src/transformers/chai-should.test.js
@@ -520,8 +520,9 @@ testChanged(
         expect(null).to.not.be.ok();
 
         const x = { ok: true };
-        expect(x.ok).toBeTruthy();
         assert.ok(x.ok);
+        expect(x.ok).toBeTruthy();
+        expect(x.ok).to.be.ok;
         `,
     `
         expect('everything').toBeTruthy();
@@ -532,8 +533,9 @@ testChanged(
         expect(null).toBeFalsy();
 
         const x = { ok: true };
-        expect(x.ok).toBeTruthy();
         assert.ok(x.ok);
+        expect(x.ok).toBeTruthy();
+        expect(x.ok).toBeTruthy();
         `
 );
 


### PR DESCRIPTION
Unfortunately we have some legacy tests that use both the `chai.assert` and `chai.expect` methods (don't ask 😔), which contain assertions similar to the following:

```javascript
const x = { ok: true }
assert.ok(x.ok)
expect(x.ok).to.be.ok
```

The `chai-assert.js` codemod works perfectly (🙌) but when the `chai-should.js` codemod is run, the results play out in one of the following ways...

**chai-assert run first**:

```javascript
// after chai-assert has been run
expect(x.ok).toBeTruthy()
expect(x.ok).to.be.ok

// after chai-should has been run
expect(x.toBeTruthy()).toBeTruthy()
expect(x.toBeTruthy()).toBeTruthy()
```

**chai-should run first**:

```javascript
// after chai-should has been run
assert.toBeTruthy()
expect(x.ok).toBeTruthy()
```

I added a reject (negated filter) condition to ensure only `ok` nodes preceded by `to` are converted. (I initially tried `ok` nodes proceeded by `be` but the `should.js` codemod failed the `should(true).ok` test as it imports the `chai-should.js` codemod). I thought this also might be useful to someone else but no worries if not. 🙂