### PR TITLE
Do not expand directories (jscodeshift handles that)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-codemods",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Codemods for migrating test files to Jest",
   "license": "MIT",
   "repository": "skovhus/jest-codemods",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -134,6 +134,11 @@ function supportFailure(supportedItems) {
     );
 }
 
+function expandFilePathsIfNeeded(filesBeforeExpansion) {
+    const shouldExpandFiles = filesBeforeExpansion.some(file => file.includes('*'));
+    return shouldExpandFiles ? globby.sync(filesBeforeExpansion) : filesBeforeExpansion;
+}
+
 inquirer
     .prompt([
         {
@@ -249,7 +254,7 @@ inquirer
         }
 
         const filesBeforeExpansion = cli.input.length ? cli.input : files;
-        const filesExpanded = globby.sync(filesBeforeExpansion);
+        const filesExpanded = expandFilePathsIfNeeded(filesBeforeExpansion);
 
         if (!filesExpanded.length) {
             console.log(`No files found matching ${filesBeforeExpansion.join(' ')}`);


### PR DESCRIPTION
https://github.com/skovhus/jest-codemods/pull/145 introduced a regression where non-globs (e.g. `.`, `src`, `tests` etc) would be expanded by `globby`. There is no need for that as `jscodeshift` already handle file paths correctly.