### PR TITLE
Add 'includeMembers' and 'includeDeepMembers' matchers

### DIFF
--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -158,7 +158,6 @@ const getArguments = (path, ignoreExpectedValue, expectedOverride) => {
 
 const unsupportedAssertions = [
     'operator',
-    'includeDeepMembers',
     'changes',
     'doesNotChange',
     'increases',
@@ -426,8 +425,6 @@ export default function transformer(fileInfo, api, options) {
             getAssertionExpression(chaiAssertExpression, 'includeMembers')
         )
         .replaceWith(path => {
-            // console.log(path.value.arguments);
-            // const [obj, prop, value] = path.value.arguments;
             return makeExpectation(
                 'toEqual',
                 path.value.arguments[0],
@@ -448,9 +445,27 @@ export default function transformer(fileInfo, api, options) {
             getAssertionExpression(chaiAssertExpression, 'notIncludeMembers')
         )
         .replaceWith(path => {
-            // console.log(path.value.arguments);
-            // const [obj, prop, value] = path.value.arguments;
             return makeNegativeExpectation(
+                'toEqual',
+                path.value.arguments[0],
+                j.callExpression(
+                    j.memberExpression(
+                        j.identifier('expect'),
+                        j.identifier('arrayContaining')
+                    ),
+                    [path.value.arguments[1]]
+                )
+            );
+        });
+
+    // assert.includeDeepMembers -> expect([]).toEqual(expect.arrayContaining([]))
+    ast
+        .find(
+            j.CallExpression,
+            getAssertionExpression(chaiAssertExpression, 'includeDeepMembers')
+        )
+        .replaceWith(path => {
+            return makeExpectation(
                 'toEqual',
                 path.value.arguments[0],
                 j.callExpression(

--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -158,7 +158,6 @@ const getArguments = (path, ignoreExpectedValue, expectedOverride) => {
 
 const unsupportedAssertions = [
     'operator',
-    'includeMembers',
     'includeDeepMembers',
     'changes',
     'doesNotChange',
@@ -419,6 +418,28 @@ export default function transformer(fileInfo, api, options) {
                 j.binaryExpression('in', path.value.arguments[1], path.value.arguments[0])
             )
         );
+
+    // assert.includeMembers -> expect([]).toEqual(expect.arrayContaining([]))
+    ast
+        .find(
+            j.CallExpression,
+            getAssertionExpression(chaiAssertExpression, 'includeMembers')
+        )
+        .replaceWith(path => {
+            // console.log(path.value.arguments);
+            // const [obj, prop, value] = path.value.arguments;
+            return makeExpectation(
+                'toEqual',
+                path.value.arguments[0],
+                j.callExpression(
+                    j.memberExpression(
+                        j.identifier('expect'),
+                        j.identifier('arrayContaining')
+                    ),
+                    [path.value.arguments[1]]
+                )
+            );
+        });
 
     // assert.isArray -> expect(Array.isArray).toBe(true)
     ast

--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -478,6 +478,26 @@ export default function transformer(fileInfo, api, options) {
             );
         });
 
+    // assert.notIncludeDeepMembers -> expect([]).not.toEqual(expect.arrayContaining([]))
+    ast
+        .find(
+            j.CallExpression,
+            getAssertionExpression(chaiAssertExpression, 'notIncludeDeepMembers')
+        )
+        .replaceWith(path => {
+            return makeNegativeExpectation(
+                'toEqual',
+                path.value.arguments[0],
+                j.callExpression(
+                    j.memberExpression(
+                        j.identifier('expect'),
+                        j.identifier('arrayContaining')
+                    ),
+                    [path.value.arguments[1]]
+                )
+            );
+        });
+
     // assert.isArray -> expect(Array.isArray).toBe(true)
     ast
         .find(j.CallExpression, getAssertionExpression(chaiAssertExpression, 'isArray'))

--- a/src/transformers/chai-assert.js
+++ b/src/transformers/chai-assert.js
@@ -441,6 +441,28 @@ export default function transformer(fileInfo, api, options) {
             );
         });
 
+    // assert.notIncludeMembers -> expect([]).not.toEqual(expect.arrayContaining([]))
+    ast
+        .find(
+            j.CallExpression,
+            getAssertionExpression(chaiAssertExpression, 'notIncludeMembers')
+        )
+        .replaceWith(path => {
+            // console.log(path.value.arguments);
+            // const [obj, prop, value] = path.value.arguments;
+            return makeNegativeExpectation(
+                'toEqual',
+                path.value.arguments[0],
+                j.callExpression(
+                    j.memberExpression(
+                        j.identifier('expect'),
+                        j.identifier('arrayContaining')
+                    ),
+                    [path.value.arguments[1]]
+                )
+            );
+        });
+
     // assert.isArray -> expect(Array.isArray).toBe(true)
     ast
         .find(j.CallExpression, getAssertionExpression(chaiAssertExpression, 'isArray'))

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -150,6 +150,10 @@ const mappings = [
     ],
     ['assert.sameMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
     ['assert.sameDeepMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+    [
+        'assert.includeMembers([1, 2, 3], [2, 1, 2]);',
+        'expect([1, 2, 3]).toEqual(expect.arrayContaining([2, 1, 2]));',
+    ],
     ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],
     ['assert.isNotExtensible(foo);', 'expect(Object.isExtensible(foo)).not.toBe(true);'],
     ['assert.isSealed(foo);', 'expect(Object.isSealed(foo)).toBe(true);'],
@@ -190,7 +194,6 @@ testChanged(
 test('not supported assertions', () => {
     const unsupportedAssertions = [
         'operator',
-        'includeMembers',
         'includeDeepMembers',
         'changes',
         'doesNotChange',
@@ -212,15 +215,14 @@ assert.${assertion}(foo, bar, baz);`,
 
     expect(consoleWarnings).toEqual([
         'jest-codemods warning: (test.js line 2) Unsupported Chai Assertion "operator".',
-        'jest-codemods warning: (test.js line 3) Unsupported Chai Assertion "includeMembers".',
-        'jest-codemods warning: (test.js line 4) Unsupported Chai Assertion "includeDeepMembers".',
-        'jest-codemods warning: (test.js line 5) Unsupported Chai Assertion "changes".',
-        'jest-codemods warning: (test.js line 6) Unsupported Chai Assertion "doesNotChange".',
-        'jest-codemods warning: (test.js line 7) Unsupported Chai Assertion "increases".',
-        'jest-codemods warning: (test.js line 8) Unsupported Chai Assertion "doesNotIncrease".',
-        'jest-codemods warning: (test.js line 9) Unsupported Chai Assertion "decreases".',
-        'jest-codemods warning: (test.js line 10) Unsupported Chai Assertion "doesNotDecrease".',
-        'jest-codemods warning: (test.js line 11) Unsupported Chai Assertion "ifError".',
+        'jest-codemods warning: (test.js line 3) Unsupported Chai Assertion "includeDeepMembers".',
+        'jest-codemods warning: (test.js line 4) Unsupported Chai Assertion "changes".',
+        'jest-codemods warning: (test.js line 5) Unsupported Chai Assertion "doesNotChange".',
+        'jest-codemods warning: (test.js line 6) Unsupported Chai Assertion "increases".',
+        'jest-codemods warning: (test.js line 7) Unsupported Chai Assertion "doesNotIncrease".',
+        'jest-codemods warning: (test.js line 8) Unsupported Chai Assertion "decreases".',
+        'jest-codemods warning: (test.js line 9) Unsupported Chai Assertion "doesNotDecrease".',
+        'jest-codemods warning: (test.js line 10) Unsupported Chai Assertion "ifError".',
     ]);
 });
 

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -158,6 +158,10 @@ const mappings = [
         'assert.notIncludeMembers([1, 2, 3], [5, 1]);',
         'expect([1, 2, 3]).not.toEqual(expect.arrayContaining([5, 1]));',
     ],
+    [
+        'assert.includeDeepMembers([{ a: 1 }, { b: 2 }, { c: 3 }], [{ b: 2 }, { a: 1 }, { b: 2 }]);',
+        'expect([{ a: 1 }, { b: 2 }, { c: 3 }]).toEqual(expect.arrayContaining([{ b: 2 }, { a: 1 }, { b: 2 }]));',
+    ],
     ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],
     ['assert.isNotExtensible(foo);', 'expect(Object.isExtensible(foo)).not.toBe(true);'],
     ['assert.isSealed(foo);', 'expect(Object.isSealed(foo)).toBe(true);'],
@@ -198,7 +202,6 @@ testChanged(
 test('not supported assertions', () => {
     const unsupportedAssertions = [
         'operator',
-        'includeDeepMembers',
         'changes',
         'doesNotChange',
         'increases',
@@ -219,14 +222,13 @@ assert.${assertion}(foo, bar, baz);`,
 
     expect(consoleWarnings).toEqual([
         'jest-codemods warning: (test.js line 2) Unsupported Chai Assertion "operator".',
-        'jest-codemods warning: (test.js line 3) Unsupported Chai Assertion "includeDeepMembers".',
-        'jest-codemods warning: (test.js line 4) Unsupported Chai Assertion "changes".',
-        'jest-codemods warning: (test.js line 5) Unsupported Chai Assertion "doesNotChange".',
-        'jest-codemods warning: (test.js line 6) Unsupported Chai Assertion "increases".',
-        'jest-codemods warning: (test.js line 7) Unsupported Chai Assertion "doesNotIncrease".',
-        'jest-codemods warning: (test.js line 8) Unsupported Chai Assertion "decreases".',
-        'jest-codemods warning: (test.js line 9) Unsupported Chai Assertion "doesNotDecrease".',
-        'jest-codemods warning: (test.js line 10) Unsupported Chai Assertion "ifError".',
+        'jest-codemods warning: (test.js line 3) Unsupported Chai Assertion "changes".',
+        'jest-codemods warning: (test.js line 4) Unsupported Chai Assertion "doesNotChange".',
+        'jest-codemods warning: (test.js line 5) Unsupported Chai Assertion "increases".',
+        'jest-codemods warning: (test.js line 6) Unsupported Chai Assertion "doesNotIncrease".',
+        'jest-codemods warning: (test.js line 7) Unsupported Chai Assertion "decreases".',
+        'jest-codemods warning: (test.js line 8) Unsupported Chai Assertion "doesNotDecrease".',
+        'jest-codemods warning: (test.js line 9) Unsupported Chai Assertion "ifError".',
     ]);
 });
 

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -162,6 +162,10 @@ const mappings = [
         'assert.includeDeepMembers([{ a: 1 }, { b: 2 }, { c: 3 }], [{ b: 2 }, { a: 1 }, { b: 2 }]);',
         'expect([{ a: 1 }, { b: 2 }, { c: 3 }]).toEqual(expect.arrayContaining([{ b: 2 }, { a: 1 }, { b: 2 }]));',
     ],
+    [
+        'assert.notIncludeDeepMembers([{ a: 1 }, { b: 2 }, { c: 3 }], [{ b: 2 }, { f: 5 }]);',
+        'expect([{ a: 1 }, { b: 2 }, { c: 3 }]).not.toEqual(expect.arrayContaining([{ b: 2 }, { f: 5 }]));',
+    ],
     ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],
     ['assert.isNotExtensible(foo);', 'expect(Object.isExtensible(foo)).not.toBe(true);'],
     ['assert.isSealed(foo);', 'expect(Object.isSealed(foo)).toBe(true);'],

--- a/src/transformers/chai-assert.test.js
+++ b/src/transformers/chai-assert.test.js
@@ -154,6 +154,10 @@ const mappings = [
         'assert.includeMembers([1, 2, 3], [2, 1, 2]);',
         'expect([1, 2, 3]).toEqual(expect.arrayContaining([2, 1, 2]));',
     ],
+    [
+        'assert.notIncludeMembers([1, 2, 3], [5, 1]);',
+        'expect([1, 2, 3]).not.toEqual(expect.arrayContaining([5, 1]));',
+    ],
     ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],
     ['assert.isNotExtensible(foo);', 'expect(Object.isExtensible(foo)).not.toBe(true);'],
     ['assert.isSealed(foo);', 'expect(Object.isSealed(foo)).toBe(true);'],


### PR DESCRIPTION
This pull request adds support for the following Chai assert matchers:
- `includeMembers`
- `notIncludeMembers`
- `includeDeepMembers`
-  `notIncludeDeepMembers`

Passing Jest conversions: https://repl.it/repls/PlaintiveHelplessScale.