### PR TITLE
Always transform chai's `string` to `toContain`

### DIFF
--- a/src/transformers/chai-should.js
+++ b/src/transformers/chai-should.js
@@ -518,6 +518,7 @@ module.exports = function transformer(fileInfo, api, options) {
                     case 'throw':
                         return createCall('toThrowError', args, rest, containsNot);
                     case 'string':
+                        return createCall('toContain', args, rest, containsNot);
                     case 'include':
                     case 'includes':
                     case 'contain':

--- a/src/transformers/chai-should.test.js
+++ b/src/transformers/chai-should.test.js
@@ -330,10 +330,14 @@ testChanged(
     `
         expect('foobar').to.have.string('bar');
         expect('foobar').not.to.have.string('z');
+        expect(someString).to.have.string('bar');
+        expect(someString).not.to.have.string('bar');
     `,
     `
         expect('foobar').toContain('bar');
         expect('foobar').not.toContain('z');
+        expect(someString).toContain('bar');
+        expect(someString).not.toContain('bar');
     `
 );
 


### PR DESCRIPTION
I thought I'd take a shot at fixing #153. Here's what I did.