### PR TITLE
jasmine-globals: Basic jasmine.clock() support

### DIFF
--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -267,5 +267,55 @@ export default function jasmineGlobals(fileInfo, api, options) {
             j(path).replaceWith(path.node.callee.object);
         });
 
+    root
+        // find all `jasmine.clock()`
+        .find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                object: {
+                    type: 'CallExpression',
+                    callee: {
+                        object: {
+                            type: 'Identifier',
+                            name: 'jasmine',
+                        },
+                        property: {
+                            type: 'Identifier',
+                            name: 'clock',
+                        },
+                    },
+                },
+            },
+        })
+        .forEach(path => {
+            const usageType = path.node.callee.property.name;
+            switch (usageType) {
+                case 'install': {
+                    // make it `jest.useFakeTimers()`
+                    path.node.callee = j.memberExpression(
+                        j.identifier('jest'),
+                        j.identifier('useFakeTimers')
+                    );
+                    break;
+                }
+                case 'uninstall': {
+                    // make it `jest.useRealTimers()`
+                    path.node.callee = j.memberExpression(
+                        j.identifier('jest'),
+                        j.identifier('useRealTimers')
+                    );
+                    break;
+                }
+                case 'tick': {
+                    // make it `jest.advanceTimersByTime(ms)`
+                    path.node.callee = j.memberExpression(
+                        j.identifier('jest'),
+                        j.identifier('advanceTimersByTime')
+                    );
+                    break;
+                }
+            }
+        });
+
     return finale(fileInfo, j, root, options);
 }

--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -3,12 +3,15 @@
  */
 
 import finale from '../utils/finale';
+import logger from '../utils/logger';
 
 export default function jasmineGlobals(fileInfo, api, options) {
     const j = api.jscodeshift;
     const root = j(fileInfo.source);
 
     const emptyArrowFn = j('() => {}').__paths[0].value.program.body[0].expression;
+
+    const logWarning = (msg, path) => logger(fileInfo, msg, path);
 
     root
         // find all `jasmine.createSpy('stuff')
@@ -311,6 +314,20 @@ export default function jasmineGlobals(fileInfo, api, options) {
                     path.node.callee = j.memberExpression(
                         j.identifier('jest'),
                         j.identifier('advanceTimersByTime')
+                    );
+                    break;
+                }
+                case 'mockDate': {
+                    logWarning(
+                        'Unsupported Jasmine functionality "jasmine.clock().mockDate(*)".',
+                        path
+                    );
+                    break;
+                }
+                default: {
+                    logWarning(
+                        `Unsupported Jasmine functionality "jasmine.clock().${usageType}".`,
+                        path
                     );
                     break;
                 }

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -76,3 +76,17 @@ testChanged(
     stuff;
     `
 );
+
+testChanged(
+    'jasmine.clock()',
+    `
+    jasmine.clock().install();
+    jasmine.clock().uninstall();
+    jasmine.clock().tick(50);
+    `,
+    `
+    jest.useFakeTimers();
+    jest.useRealTimers();
+    jest.advanceTimersByTime(50);
+    `
+);

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -13,6 +13,12 @@ function testChanged(msg, source, expectedOutput) {
     });
 }
 
+let consoleWarnings = [];
+beforeEach(() => {
+    consoleWarnings = [];
+    console.warn = v => consoleWarnings.push(v);
+});
+
 testChanged(
     'spyOn',
     `
@@ -90,3 +96,15 @@ testChanged(
     jest.advanceTimersByTime(50);
     `
 );
+
+test('not supported jasmine.clock()', () => {
+    wrappedPlugin(`
+        jasmine.clock().mockDate(new Date(2013, 9, 23));
+        jasmine.clock().unknownUtil();
+    `);
+
+    expect(consoleWarnings).toEqual([
+        'jest-codemods warning: (test.js line 2) Unsupported Jasmine functionality "jasmine.clock().mockDate(*)".',
+        'jest-codemods warning: (test.js line 3) Unsupported Jasmine functionality "jasmine.clock().unknownUtil".',
+    ]);
+});


### PR DESCRIPTION
Adds basic support for `jasmine.clock()` timer mocking by replacing it with jest timers:

Jasmine:
https://jasmine.github.io/api/edge/Clock.html
https://jasmine.github.io/2.9/introduction#section-Jasmine_Clock

Jest:
https://jestjs.io/docs/en/timer-mocks.html