### PR TITLE
jasmine-globals: Support *.calls.argsFor(index)

### DIFF
--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -328,6 +328,36 @@ export default function jasmineGlobals(fileInfo, api, options) {
         });
 
     root
+        // find `*.calls.argsFor(index)`
+        .find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                object: {
+                    type: 'MemberExpression',
+                    property: {
+                        type: 'Identifier',
+                        name: 'calls',
+                    },
+                },
+                property: {
+                    type: 'Identifier',
+                    name: 'argsFor',
+                },
+            },
+        })
+        .forEach(path => {
+            const expressionMockCalls = j.memberExpression(
+                j.memberExpression(path.node.callee.object.object, j.identifier('mock')),
+                j.identifier('calls')
+            );
+
+            // make it `*.mock.calls[index]`
+            j(path).replaceWith(
+                j.memberExpression(expressionMockCalls, path.node.arguments[0])
+            );
+        });
+
+    root
         // replace `andCallFake` with `mockImplementation`
         .find(j.MemberExpression, {
             property: {

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -80,8 +80,6 @@ testChanged(
     getMock(stuff).calls.count() > 1;
     wyoming.cheyenne.callCount
     args.map()
-    oklahoma.argsForCall[0]
-    idaho.argsForCall[0][1]
     spyOn('stuff').andCallFake(fn);
     hmm.andCallFake(fn);
     spyOn('stuff').andReturn('lol');
@@ -95,8 +93,6 @@ testChanged(
     getMock(stuff).mock.calls.length > 1;
     wyoming.cheyenne.mock.calls.length
     args.map()
-    oklahoma.mock.calls[0]
-    idaho.mock.calls[0][1]
     jest.spyOn('stuff').mockImplementation(fn);
     hmm.mockImplementation(fn);
     jest.spyOn('stuff').mockReturnValue('lol');
@@ -130,6 +126,30 @@ testChanged(
     someMock.mock.calls[someMock.mock.calls.length - 1][0];
 
     foo.mostRecent();
+    `
+);
+
+testChanged(
+    '*.argsForCall',
+    `
+    oklahoma.argsForCall[0]
+    idaho.argsForCall[0][1]
+    `,
+    `
+    oklahoma.mock.calls[0]
+    idaho.mock.calls[0][1]
+    `
+);
+
+testChanged(
+    '*.calls.argsFor()',
+    `
+    oklahoma.calls.argsFor(0)
+    idaho.calls.argsFor(0)[1]
+    `,
+    `
+    oklahoma.mock.calls[0]
+    idaho.mock.calls[0][1]
     `
 );
 


### PR DESCRIPTION
Supports `*.calls.argsFor(index)`

https://jasmine.github.io/2.9/introduction#section-33

Replaces it with `*.mock.calls[index]`, the same approach currently used by the `*. argsForCall` logic

Jest calls docs: https://jestjs.io/docs/en/mock-function-api#mockfnmockcalls