### PR TITLE
Upgrade Prettier to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "husky": "^0.14.3",
     "jest": "^23.6.0",
     "lint-staged": "^4.2.3",
-    "prettier": "^1.7.4"
+    "prettier": "^1.8.2"
   },
   "resolutions": {
     "babel-core": "^7.0.0-bridge.0",

--- a/src/transformers/expect.js
+++ b/src/transformers/expect.js
@@ -135,8 +135,9 @@ export default function expectTransformer(fileInfo, api, options) {
         }
 
         logWarning(
-            `Too many arguments given to "${newJestMatcherName}". Expected max ${maxArgs} but got ${matcherNode
-                .arguments.length}`,
+            `Too many arguments given to "${newJestMatcherName}". Expected max ${
+                maxArgs
+            } but got ${matcherNode.arguments.length}`,
             path
         );
     }
@@ -269,8 +270,9 @@ ${keys}.forEach(e => {
                     findParentOfType(path, 'AssignmentExpression');
                 if (!parentAssignment) {
                     logWarning(
-                        `"${path.value.property
-                            .name}" without variable assignment might not work as expected (see https://facebook.github.io/jest/docs/jest-object.html#jestspyonobject-methodname)`,
+                        `"${
+                            path.value.property.name
+                        }" without variable assignment might not work as expected (see https://facebook.github.io/jest/docs/jest-object.html#jestspyonobject-methodname)`,
                         path
                     );
                 }

--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -64,7 +64,9 @@ export default function jasmineGlobals(fileInfo, api, options) {
                 }
                 default: {
                     logWarning(
-                        `Unsupported Jasmine functionality "jasmine.createSpy().and.${spyType}".`,
+                        `Unsupported Jasmine functionality "jasmine.createSpy().and.${
+                            spyType
+                        }".`,
                         path
                     );
                     break;
@@ -453,7 +455,9 @@ export default function jasmineGlobals(fileInfo, api, options) {
                 }
                 default: {
                     logWarning(
-                        `Unsupported Jasmine functionality "jasmine.clock().${usageType}".`,
+                        `Unsupported Jasmine functionality "jasmine.clock().${
+                            usageType
+                        }".`,
                         path
                     );
                     break;

--- a/src/transformers/tape.js
+++ b/src/transformers/tape.js
@@ -115,7 +115,9 @@ export default function tapeToJest(fileInfo, api, options) {
                     const propertyName = p.value.callee.property.name;
                     if (propertyName.toLowerCase().indexOf('looseequal') >= 0) {
                         logWarning(
-                            `"t.${propertyName}" is currently not supported. Try the stricter "toEqual" or "not.toEqual"`,
+                            `"t.${
+                                propertyName
+                            }" is currently not supported. Try the stricter "toEqual" or "not.toEqual"`,
                             p
                         );
                     } else {

--- a/src/utils/tape-ava-helpers.js
+++ b/src/utils/tape-ava-helpers.js
@@ -188,7 +188,9 @@ export function detectUnsupportedNaming(fileInfo, j, ast, testFunctionName) {
                 if (lastArgName !== 't') {
                     logger(
                         fileInfo,
-                        `Argument to test function should be named "t" not "${lastArgName}"`,
+                        `Argument to test function should be named "t" not "${
+                            lastArgName
+                        }"`,
                         p
                     );
                 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,10 +4881,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
-  integrity sha1-XoYkrpNjyA+V7GRFhOzfVddPk/o=
+prettier@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
+  integrity sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==
 
 pretty-format@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
Not a change I'd typically suggest to an open source repo, but hoping you don't mind a formatting migration to >=1.8.x of Prettier since it's a fairly small diff.

Currently there is a bug in the VS Code extension for Prettier which prohibits it from working on versions < 1.8.x since `prettierInstance.getSupportInfo` isn't defined. Context: https://github.com/prettier/prettier-vscode/issues/710

Not the end of the world, but working without Prettier on save is a bit less than ideal 😭.

Let me know if there is a format you'd rather have this sort of change done. It may also make sense to go straight to the latest version, but I'll leave that change up to you (it would be a fairly large diff) 😬

TODO:
- [x] Regenerate `yarn.lock` with a version of yarn that includes the `integrity sha1` 