### PR TITLE
jasmine-globals: Support expect.<>(*) functions

### DIFF
--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -465,5 +465,36 @@ export default function jasmineGlobals(fileInfo, api, options) {
             }
         });
 
+    const jasmineToExpectFunctionNames = [
+        'any',
+        'anything',
+        'arrayContaining',
+        'objectContaining',
+        'stringMatching',
+    ];
+
+    jasmineToExpectFunctionNames.forEach(functionName => {
+        // jasmine.<jasmineToExpectFunctionName>(*)
+        root
+            .find(j.CallExpression, {
+                callee: {
+                    type: 'MemberExpression',
+                    object: {
+                        type: 'Identifier',
+                        name: 'jasmine',
+                    },
+                    property: {
+                        type: 'Identifier',
+                        name: functionName,
+                    },
+                },
+            })
+            .forEach(path => {
+                // `jasmine.<jasmineToExpectFunctionName>(*)` is equivalent of
+                // `expect.<jasmineToExpectFunctionName>(*)`
+                path.node.callee.object.name = 'expect';
+            });
+    });
+
     return finale(fileInfo, j, root, options);
 }

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -178,3 +178,21 @@ test('not supported jasmine.clock()', () => {
         'jest-codemods warning: (test.js line 3) Unsupported Jasmine functionality "jasmine.clock().unknownUtil".',
     ]);
 });
+
+testChanged(
+    'jasmine.<jasmineToExpectFunctionName>(*)',
+    `
+    jasmine.any(Function);
+    jasmine.anything();
+    jasmine.arrayContaining(['foo']);
+    jasmine.objectContaining({ foo: 'bar' });
+    jasmine.stringMatching('text');
+    `,
+    `
+    expect.any(Function);
+    expect.anything();
+    expect.arrayContaining(['foo']);
+    expect.objectContaining({ foo: 'bar' });
+    expect.stringMatching('text');
+    `
+);


### PR DESCRIPTION
These utils should be 1:1

`any`: [Jasmine](https://jasmine.github.io/2.9/introduction#section-Matching_Anything_with_%3Ccode%3Ejasmine.any%3C/code%3E) / [Jest](https://jestjs.io/docs/en/expect#expectany)

`anything`: [Jasmine](https://jasmine.github.io/2.9/introduction#section-Matching_existence_with_%3Ccode%3Ejasmine.anything%3C/code%3E) / [Jest](https://jestjs.io/docs/en/expect#expectanything)

`arrayContaining `: [Jasmine](https://jasmine.github.io/2.9/introduction#section-Partial_Array_Matching_with_%3Ccode%3Ejasmine.arrayContaining%3C/code%3E) / [Jest](https://jestjs.io/docs/en/expect#expectarraycontainingarray)

`objectContaining `: [Jasmine](https://jasmine.github.io/2.9/introduction#section-Partial_Matching_with_%3Ccode%3Ejasmine.objectContaining%3C/code%3E) / [Jest](https://jestjs.io/docs/en/expect#expectobjectcontainingobject)

`stringMatching `: [Jasmine](https://jasmine.github.io/2.9/introduction#section-String_Matching_with_%3Ccode%3Ejasmine.stringMatching%3C/code%3E) / [Jest](https://jestjs.io/docs/en/expect#expectstringmatchingstring-regexp)
