### PR TITLE
Add support for migrating jasmine.createSpyObj

### DIFF
--- a/src/transformers/jasmine-globals.js
+++ b/src/transformers/jasmine-globals.js
@@ -490,5 +490,37 @@ export default function jasmineGlobals(fileInfo, api, options) {
         });
     });
 
+    root.find(j.CallExpression, {
+        callee: {
+            type: 'MemberExpression',
+            object: {
+                type: 'Identifier',
+                name: 'jasmine',
+            },
+            property: {
+                type: 'Identifier',
+                name: 'createSpyObj',
+            },
+        },
+    })
+        .filter(
+            path =>
+                path.node.arguments.length === 2 &&
+                path.node.arguments[1].type === 'ArrayExpression'
+        )
+        .forEach(path => {
+            const properties = path.node.arguments[1].elements.map(arg =>
+                j.objectProperty(
+                    j.literal(arg.value),
+                    j.callExpression(
+                        j.memberExpression(j.identifier('jest'), j.identifier('fn')),
+                        []
+                    )
+                )
+            );
+
+            j(path).replaceWith(j.objectExpression(properties));
+        });
+
     return finale(fileInfo, j, root, options);
 }

--- a/src/transformers/jasmine-globals.test.js
+++ b/src/transformers/jasmine-globals.test.js
@@ -196,3 +196,17 @@ testChanged(
     expect.stringMatching('text');
     `
 );
+
+testChanged(
+    'createSpyObj',
+    `
+    const spyObj = jasmine.createSpyObj('label', ['a', 'b', 'hyphen-ated']);
+    `,
+    `
+    const spyObj = {
+        'a': jest.fn(),
+        'b': jest.fn(),
+        'hyphen-ated': jest.fn()
+    };
+    `
+);


### PR DESCRIPTION
Add support for migrating `jasmine.createSpyObj` to an object containing `jest.fn()`s