### PR TITLE
Add ts parser option, to be compatible with <> type casts

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -4,7 +4,6 @@ import globby from 'globby';
 import inquirer from 'inquirer';
 import meow from 'meow';
 import updateNotifier from 'update-notifier';
-
 import checkGitStatus from './git-status';
 import { executeTransformations } from './transformers';
 
@@ -123,6 +122,10 @@ const PARSER_INQUIRER_CHOICES = [
     },
     {
         name: 'TypeScript',
+        value: 'ts',
+    },
+    {
+        name: 'TypeScript & TSX',
         value: 'tsx',
     },
 ];

--- a/src/cli/transformers.js
+++ b/src/cli/transformers.js
@@ -20,6 +20,8 @@ function executeTransformation({ files, flags, parser, transformer, transformerA
     args.push('--parser', parser);
     if (parser === 'tsx') {
         args.push('--extensions=tsx,ts');
+    } else if (parser === 'ts') {
+        args.push('--extensions=ts');
     }
 
     if (transformerArgs && transformerArgs.length > 0) {


### PR DESCRIPTION
This PR adds an option to the CLI to choose the ts parser instead of the tsx parser.

Fixes #151 