### PR TITLE
Add the ability to bypass prompts by passing command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ To use the interactive CLI run
 
 	$ npx jest-codemods
 
-If you do not have `npx` installed, you can install the `jest-codemods` command globally by running `npm install -g jest-codemods`.
+If you do not have `npx` installed, you can install the `jest-codemods` command globally by running `npm install -g jest-codemods`. 
+
+Command line arguments can be used to bypass prompts. Invalid values for arguments will be ignored.
 
 For more options
 ```
@@ -50,10 +52,16 @@ $ npx jest-codemods --help
 
     Examples:   npx jest-codemods src
                 npx jest-codemods src/**/*.test.js
+                npx jest-codemods src/**/*.test.js --parser=babel --skipImportDetection=0 --standaloneMode
 
     Options:
-      -f, --force       Bypass Git safety checks and force codemods to run
-      -d, --dry         Dry run (no changes are made to files)
+      -f, --force             Bypass Git safety checks and force codemods to run
+      -d, --dry               Dry run (no changes are made to files)
+      --parser                The parser to use (babel, flow, ts, tsx)
+      --transformer           The transformer to use (ava,     chai-assert, chai-should, expect-js, expect, jasmine-globals,     jasmine-this, mocha, should, tape)
+      --skipImportDetection   Keep using the global object for     assertions
+      --standaloneMode        Use explicit require calls instead of     globals
+      --mochaAssertion        Use assertion transformations with Mocha (chai-assert, chai-should, expect-js, expect, should)
 ```
 
 To transform all test files in a directory run `jest-codemods .` in your terminal.


### PR DESCRIPTION
Users would be able to bypass all prompts by passing the options via command line. A complete example looks like this:

```
> npx jest-codemods src/cli/**/*.test.ts --force --parser=tsx --transformer=mocha --mochaAssertion=chai-should --standaloneMode=0 --skipImportDetection

NOTICE: Skipping import detection, you might get false positives
Executing command: jscodeshift -t /Users/jonathan.waltner/git/jest-codemods/dist/transformers/mocha.js src/cli/git-status.test.ts src/cli/transformers.test.ts --ignore-pattern node_modules --parser tsx --extensions=tsx,ts --skipImportDetection=true
Processing 2 files... 
Spawning 2 workers...
Sending 1 files to free worker...
Sending 1 files to free worker...
All done. 
Results: 
0 errors
2 unmodified
0 skipped
0 ok
Time elapsed: 0.888seconds 
Executing command: jscodeshift -t /Users/jonathan.waltner/git/jest-codemods/dist/transformers/chai-should.js src/cli/git-status.test.ts src/cli/transformers.test.ts --ignore-pattern node_modules --parser tsx --extensions=tsx,ts --skipImportDetection=true
Processing 2 files... 
Spawning 2 workers...
Sending 1 files to free worker...
Sending 1 files to free worker...
All done. 
Results: 
0 errors
0 unmodified
2 skipped
0 ok
Time elapsed: 0.665seconds 
```

This allows for integration with editors and for easy consistency when doing a piecemeal conversion of an existing test suite on a large codebase.