### PR TITLE
Transformation Test Refactoring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,5 +57,11 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    'jest/expect-expect': [
+      'error',
+      {
+        assertFunctionNames: ['expect', 'expectTransformation'],
+      },
+    ],
   },
 }

--- a/src/transformers/ava.test.ts
+++ b/src/transformers/ava.test.ts
@@ -13,14 +13,14 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function assertTransformation(source, expectedOutput, options = {}) {
+function expectTransformation(source, expectedOutput, options = {}) {
   const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
 }
 
 test('does not touch code without ava require/import', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 const test = require("testlib");
@@ -39,7 +39,7 @@ test(t => {
 })
 
 test('changes code without require/import if skipImportDetection is set', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 test(t => {
@@ -58,7 +58,7 @@ test(t => {
 
 // TODO: jscodeshift adds semi colon when preserving first line comments :/
 test('maps assertions', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 import test from 'ava'
@@ -129,7 +129,7 @@ test('mapping', () => {
 })
 
 test('handles test setup/teardown modifiers', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava'
 
@@ -148,7 +148,7 @@ afterEach(() => {});
 })
 
 test('all tests are serial by default', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava'
 test.serial(t => {});
@@ -160,7 +160,7 @@ test(() => {});
 })
 
 test('handles skip/only modifiers and chaining', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava'
 
@@ -185,7 +185,7 @@ test.only(() => {});
 })
 
 test('removes t.pass, but keeps t.fail', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava'
 
@@ -222,7 +222,7 @@ test.only('handles done.fail and done.pass', done => {
 // TODO: semantics is not the same for t.end and done
 // t.end automatically checks for error as first argument (jasmine doesn't)
 test('callback tests', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava';
 test.cb(t => {
@@ -239,7 +239,7 @@ test(done => {
 
 // TODO: these hanging t variables should be removed or be renamed
 test('passing around t', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava'
 
@@ -278,7 +278,7 @@ function shouldFail2(t, message) {
 })
 
 test('keeps async and await', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava';
 
@@ -307,7 +307,7 @@ test(async function () {
 })
 
 test('destructured test argument', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava';
 test(({ok}) => {
@@ -329,7 +329,7 @@ test('my test', () => {
 })
 
 test('converts test.todo', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import test from 'ava';
 test.todo('this should be a test some day');
@@ -428,7 +428,7 @@ test('warns about too few AVA arguments', () => {
 })
 
 test('supports renaming non standard import name', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import foo from 'ava';
 foo(() => {});

--- a/src/transformers/ava.test.ts
+++ b/src/transformers/ava.test.ts
@@ -13,53 +13,53 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(msg, source, expectedOutput, options = {}) {
-  test(msg, () => {
-    const result = wrappedPlugin(source, options)
-    expect(result).toBe(expectedOutput)
-    expect(consoleWarnings).toEqual([])
-  })
+function assertTransformation(source, expectedOutput, options = {}) {
+  const result = wrappedPlugin(source, options)
+  expect(result).toBe(expectedOutput)
+  expect(consoleWarnings).toEqual([])
 }
 
-testChanged(
-  'does not touch code without ava require/import',
-  `
+test('does not touch code without ava require/import', () => {
+  assertTransformation(
+    `
 // @flow
 const test = require("testlib");
 test(t => {
     t.notOk(1);
 })
 `,
-  `
+    `
 // @flow
 const test = require("testlib");
 test(t => {
     t.notOk(1);
 })
 `
-)
+  )
+})
 
-testChanged(
-  'changes code without require/import if skipImportDetection is set',
-  `
+test('changes code without require/import if skipImportDetection is set', () => {
+  assertTransformation(
+    `
 // @flow
 test(t => {
     t.notOk(1);
 })
 `,
-  `
+    `
 // @flow
 test(t => {
     expect(1).toBeFalsy();
 })
 `,
-  { skipImportDetection: true }
-)
+    { skipImportDetection: true }
+  )
+})
 
 // TODO: jscodeshift adds semi colon when preserving first line comments :/
-testChanged(
-  'maps assertions',
-  `
+test('maps assertions', () => {
+  assertTransformation(
+    `
 // @flow
 import test from 'ava'
 
@@ -93,7 +93,7 @@ test('mapping', (t) => {
   t.snapshot(abc, {}, "msg")
 })
 `,
-  `
+    `
 // @flow
 test('mapping', () => {
   const abc = { a: 'a', b: 'b', c: 'c' }
@@ -125,11 +125,12 @@ test('mapping', () => {
   expect(abc).toMatchSnapshot("msg")
 });
 `
-)
+  )
+})
 
-testChanged(
-  'handles test setup/teardown modifiers',
-  `
+test('handles test setup/teardown modifiers', () => {
+  assertTransformation(
+    `
 import test from 'ava'
 
 test.before(t => {});
@@ -137,28 +138,30 @@ test.after(t => {});
 test.beforeEach(t => {});
 test.afterEach(t => {});
 `,
-  `
+    `
 beforeAll(() => {});
 afterAll(() => {});
 beforeEach(() => {});
 afterEach(() => {});
 `
-)
+  )
+})
 
-testChanged(
-  'all tests are serial by default',
-  `
+test('all tests are serial by default', () => {
+  assertTransformation(
+    `
 import test from 'ava'
 test.serial(t => {});
 `,
-  `
+    `
 test(() => {});
 `
-)
+  )
+})
 
-testChanged(
-  'handles skip/only modifiers and chaining',
-  `
+test('handles skip/only modifiers and chaining', () => {
+  assertTransformation(
+    `
 import test from 'ava'
 
 test.only(t => {});
@@ -169,7 +172,7 @@ test.skip.serial(t => {});
 test.only.serial(t => {});
 test.serial.only(t => {});
 `,
-  `
+    `
 test.only(() => {});
 test.skip(() => {});
 
@@ -178,11 +181,12 @@ test.skip(() => {});
 test.only(() => {});
 test.only(() => {});
 `
-)
+  )
+})
 
-testChanged(
-  'removes t.pass, but keeps t.fail',
-  `
+test('removes t.pass, but keeps t.fail', () => {
+  assertTransformation(
+    `
 import test from 'ava'
 
 test('handles done.fail and done.pass', t => {
@@ -199,7 +203,7 @@ test.serial.only('handles done.fail and done.pass', t => {
     }, 500);
 });
 `,
-  `
+    `
 test('handles done.fail and done.pass', done => {
     setTimeout(() => {
         done.fail('no');
@@ -212,29 +216,31 @@ test.only('handles done.fail and done.pass', done => {
     }, 500);
 });
 `
-)
+  )
+})
 
 // TODO: semantics is not the same for t.end and done
 // t.end automatically checks for error as first argument (jasmine doesn't)
-testChanged(
-  'callback tests',
-  `
+test('callback tests', () => {
+  assertTransformation(
+    `
 import test from 'ava';
 test.cb(t => {
     fs.readFile('data.txt', t.end);
 });
 `,
-  `
+    `
 test(done => {
     fs.readFile('data.txt', done);
 });
 `
-)
+  )
+})
 
 // TODO: these hanging t variables should be removed or be renamed
-testChanged(
-  'passing around t',
-  `
+test('passing around t', () => {
+  assertTransformation(
+    `
 import test from 'ava'
 
 test('should pass', t => {
@@ -252,7 +258,7 @@ function shouldFail2(t, message) {
     })
 }
 `,
-  `
+    `
 test('should pass', () => {
     shouldFail(t, 'hi')
     return shouldFail2(t, 'hi')
@@ -268,11 +274,12 @@ function shouldFail2(t, message) {
     });
 }
 `
-)
+  )
+})
 
-testChanged(
-  'keeps async and await',
-  `
+test('keeps async and await', () => {
+  assertTransformation(
+    `
 import test from 'ava';
 
 test(async (t) => {
@@ -285,7 +292,7 @@ test(async function (t) {
     t.true(value);
 });
 `,
-  `
+    `
 test(async () => {
     const value = await promiseFn();
     expect(value).toBe(true);
@@ -296,11 +303,12 @@ test(async function () {
     expect(value).toBe(true);
 });
 `
-)
+  )
+})
 
-testChanged(
-  'destructured test argument',
-  `
+test('destructured test argument', () => {
+  assertTransformation(
+    `
 import test from 'ava';
 test(({ok}) => {
     ok('msg');
@@ -309,7 +317,7 @@ test('my test', ({is}) => {
     is('msg', 'other msg');
 });
 `,
-  `
+    `
 test(() => {
     expect('msg').toBeTruthy();
 });
@@ -317,18 +325,20 @@ test('my test', () => {
     expect('msg').toBe('other msg');
 });
 `
-)
+  )
+})
 
-testChanged(
-  'converts test.todo',
-  `
+test('converts test.todo', () => {
+  assertTransformation(
+    `
 import test from 'ava';
 test.todo('this should be a test some day');
 `,
-  `
+    `
 test.todo('this should be a test some day');
 `
-)
+  )
+})
 
 test('not supported warnings: skipping test setup/teardown hooks', () => {
   wrappedPlugin(`
@@ -417,13 +427,14 @@ test('warns about too few AVA arguments', () => {
   ])
 })
 
-testChanged(
-  'supports renaming non standard import name',
-  `
+test('supports renaming non standard import name', () => {
+  assertTransformation(
+    `
 import foo from 'ava';
 foo(() => {});
 `,
-  `
+    `
 test(() => {});
 `
-)
+  )
+})

--- a/src/transformers/chai-assert.test.ts
+++ b/src/transformers/chai-assert.test.ts
@@ -13,14 +13,14 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function assertTransformation(source, expectedOutput, options = {}) {
+function expectTransformation(source, expectedOutput, options = {}) {
   const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
 }
 
 test('does not change if chai is not imported', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 assert.equal(foo, bar, baz);
@@ -33,7 +33,7 @@ assert.equal(foo, bar, baz);
 })
 
 test('does not change if assert is not imported from chai', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 import { should } from 'chai';
@@ -46,7 +46,7 @@ import { should } from 'chai';
 })
 
 test('does not change if assert is not required from chai', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 const should = require('chai').should;
@@ -205,11 +205,11 @@ import { assert } from 'chai';`,
   )
 
   test('mappings', () => {
-    assertTransformation(mappingTest.input, mappingTest.output)
+    expectTransformation(mappingTest.input, mappingTest.output)
   })
 
   test('mapping without import if skipImportDetection is set', () => {
-    assertTransformation(
+    expectTransformation(
       mappingTest.input.replace("import { assert } from 'chai';\n", ''),
       mappingTest.output,
       { skipImportDetection: true }
@@ -248,7 +248,7 @@ assert.${assertion}(foo, bar, baz);`,
 })
 
 test('applies when chai default import used', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 import chai from 'chai';
@@ -262,7 +262,7 @@ expect(foo).toEqual(bar);
 })
 
 test('transforms renamed imports', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 import { assert as myCoolAssert } from 'chai';

--- a/src/transformers/chai-assert.test.ts
+++ b/src/transformers/chai-assert.test.ts
@@ -13,204 +13,209 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(msg, source, expectedOutput, options = {}) {
-  test(msg, () => {
-    const result = wrappedPlugin(source, options)
-    expect(result).toBe(expectedOutput)
-    expect(consoleWarnings).toEqual([])
-  })
+function assertTransformation(source, expectedOutput, options = {}) {
+  const result = wrappedPlugin(source, options)
+  expect(result).toBe(expectedOutput)
+  expect(consoleWarnings).toEqual([])
 }
 
-testChanged(
-  'does not change if chai is not imported',
-  `
+test('does not change if chai is not imported', () => {
+  assertTransformation(
+    `
 // @flow
 assert.equal(foo, bar, baz);
 `,
-  `
+    `
 // @flow
 assert.equal(foo, bar, baz);
 `
-)
+  )
+})
 
-testChanged(
-  'does not change if assert is not imported from chai',
-  `
+test('does not change if assert is not imported from chai', () => {
+  assertTransformation(
+    `
 // @flow
 import { should } from 'chai';
 `,
-  `
+    `
 // @flow
 import { should } from 'chai';
 `
-)
+  )
+})
 
-testChanged(
-  'does not change if assert is not required from chai',
-  `
+test('does not change if assert is not required from chai', () => {
+  assertTransformation(
+    `
 // @flow
 const should = require('chai').should;
 `,
-  `
+    `
 // @flow
 const should = require('chai').should;
 `
-)
+  )
+})
 
-const mappings = [
-  // follow the ordering here: http://chaijs.com/api/assert/
-  ['assert(foo === bar, baz);', 'expect(foo === bar).toBeTruthy();'],
-  ['assert(Array.isArray([]));', 'expect(Array.isArray([])).toBeTruthy();'],
-  ['assert.fail(foo, bar, baz);', 'expect(false).toBe(true);'],
-  ['assert.isOk(foo, msg);', 'expect(foo).toBeTruthy();'],
-  ['assert.isNotOk(foo);', 'expect(foo).toBeFalsy();'],
-  ['assert.equal(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
-  ['assert.notEqual(foo, bar, baz);', 'expect(foo).not.toEqual(bar);'],
-  ['assert.strictEqual(foo, bar, baz);', 'expect(foo).toBe(bar);'],
-  ['assert.notStrictEqual(foo, bar, baz);', 'expect(foo).not.toBe(bar);'],
-  ['assert.deepEqual(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
-  ['assert.notDeepEqual(foo, bar, baz);', 'expect(foo).not.toEqual(bar);'],
-  ['assert.isAbove(foo, bar, baz);', 'expect(foo).toBeGreaterThan(bar);'],
-  ['assert.isAtLeast(foo, bar, baz);', 'expect(foo).toBeGreaterThanOrEqual(bar);'],
-  ['assert.isBelow(foo, bar, baz);', 'expect(foo).toBeLessThan(bar);'],
-  ['assert.isAtMost(foo, bar, baz);', 'expect(foo).toBeLessThanOrEqual(bar);'],
-  ['assert.isTrue(foo);', 'expect(foo).toBe(true);'],
-  ['assert.isTrue(foo, msg);', 'expect(foo).toBe(true);'],
-  ['assert.isNotTrue(foo, msg);', 'expect(foo).not.toBe(true);'],
-  ['assert.isFalse(foo, msg);', 'expect(foo).toBe(false);'],
-  ['assert.isNotFalse(foo, msg);', 'expect(foo).not.toBe(false);'],
-  ['assert.isNull(foo, msg);', 'expect(foo).toBeNull();'],
-  ['assert.isNotNull(foo, msg);', 'expect(foo).not.toBeNull();'],
-  ['assert.isNaN(foo, msg);', 'expect(foo).toBe();'],
-  ['assert.isNotNaN(foo, msg);', 'expect(foo).not.toBe();'],
-  ['assert.isUndefined(foo, msg);', 'expect(foo).not.toBeDefined();'],
-  ['assert.isDefined(foo, msg);', 'expect(foo).toBeDefined();'],
-  ['assert.isFunction(foo, msg);', "expect(typeof foo).toBe('function');"],
-  ['assert.isNotFunction(foo, msg);', "expect(typeof foo).not.toBe('function');"],
-  ['assert.isObject(foo, msg);', "expect(typeof foo).toBe('object');"],
-  ['assert.isNotObject(foo, msg);', "expect(typeof foo).not.toBe('object');"],
-  ['assert.isArray(foo, msg);', 'expect(Array.isArray(foo)).toBe(true);'],
-  ['assert.isNotArray(foo, msg);', 'expect(Array.isArray(foo)).not.toBe(true);'],
-  ['assert.isString(foo, msg);', "expect(typeof foo).toBe('string');"],
-  ['assert.isNotString(foo, msg);', "expect(typeof foo).not.toBe('string');"],
-  ['assert.isNumber(foo, msg);', "expect(typeof foo).toBe('number');"],
-  ['assert.isNotNumber(foo, msg);', "expect(typeof foo).not.toBe('number');"],
-  ['assert.isBoolean(foo, msg);', "expect(typeof foo).toBe('boolean');"],
-  ['assert.isNotBoolean(foo, msg);', "expect(typeof foo).not.toBe('boolean');"],
-  ['assert.typeOf(foo, bar, baz);', 'expect(typeof foo).toBe(bar);'],
-  ['assert.notTypeOf(foo, bar, baz);', 'expect(typeof foo).not.toBe(bar);'],
-  ['assert.instanceOf(foo, bar, baz);', 'expect(foo).toBeInstanceOf(bar);'],
-  ['assert.notInstanceOf(foo, bar, baz);', 'expect(foo).not.toBeInstanceOf(bar);'],
-  ['assert.include(foo, bar, baz);', 'expect(foo).toContain(bar);'],
-  ['assert.notInclude(foo, bar, baz);', 'expect(foo).not.toContain(bar);'],
-  ['assert.match(foo, bar, baz);', 'expect(foo).toMatch(bar);'],
-  ['assert.notMatch(foo, bar, baz);', 'expect(foo).not.toMatch(bar);'],
-  ['assert.property(foo, bar, baz);', 'expect(bar in foo).toBeTruthy();'],
-  ['assert.notProperty(foo, bar, baz);', 'expect(bar in foo).toBeFalsy();'],
-  [
-    "assert.deepProperty({ tea: { green: 'matcha' }}, 'tea.green');",
-    "expect({ tea: { green: 'matcha' }}).toHaveProperty('tea.green');",
-  ],
-  [
-    "assert.notDeepProperty({ tea: { green: 'matcha' }}, 'tea.oolong');",
-    "expect({ tea: { green: 'matcha' }}).not.toHaveProperty('tea.oolong');",
-  ],
-  ['assert.propertyVal(foo, bar, baz);', 'expect(foo.bar).toBe(baz);'],
-  ['assert.propertyNotVal(foo, bar, baz);', 'expect(foo.bar).not.toBe(baz);'],
-  ['assert.notPropertyVal(foo, bar, baz);', 'expect(foo.bar).not.toBe(baz);'],
-  ['assert.nestedProperty(foo, bar);', 'expect(foo).toHaveProperty(bar);'],
-  ['assert.notNestedProperty(foo, bar);', 'expect(foo).not.toHaveProperty(bar);'],
-  ['assert.nestedPropertyVal(foo, bar, baz);', 'expect(foo).toHaveProperty(bar, baz);'],
-  [
-    'assert.notNestedPropertyVal(foo, bar, baz);',
-    'expect(foo).not.toHaveProperty(bar, baz);',
-  ],
-  [
-    "assert.deepPropertyVal({ tea: { green: 'matcha' } }, 'tea', { green: 'matcha' });",
-    "expect({ tea: { green: 'matcha' } }).toHaveProperty('tea', { green: 'matcha' });",
-  ],
-  [
-    "assert.notDeepPropertyVal({ tea: { green: 'matcha' } }, 'tea', { black: 'matcha' });",
-    "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('tea', { black: 'matcha' });",
-  ],
-  [
-    "assert.deepPropertyNotVal({ tea: { green: 'matcha' } }, 'tea', { green: 'oolong' });",
-    "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('tea', { green: 'oolong' });",
-  ],
-  [
-    "assert.notDeepPropertyVal({ tea: { green: 'matcha' } }, 'tea', { green: 'oolong' });",
-    "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('tea', { green: 'oolong' });",
-  ],
-  [
-    "assert.notDeepPropertyVal({ tea: { green: 'matcha' } }, 'coffee', { green: 'matcha' });",
-    "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('coffee', { green: 'matcha' });",
-  ],
-  ['assert.lengthOf(foo, bar, baz);', 'expect(foo.length).toBe(bar);'],
-  ['assert.throws(foo, bar, baz);', 'expect(foo).toThrow();'],
-  ['assert.doesNotThrow(foo, bar, baz);', 'expect(foo).not.toThrow();'],
-  [
-    'assert.closeTo(foo, bar, baz, msg);',
-    'expect(Math.abs(foo - bar)).toBeLessThanOrEqual(baz);',
-  ],
-  [
-    'assert.approximately(foo, bar, baz);',
-    'expect(Math.abs(foo - bar)).toBeLessThanOrEqual(baz);',
-  ],
-  ['assert.sameMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
-  ['assert.sameDeepMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
-  ['assert.ifError(foo);', 'expect(foo).toBeFalsy();'],
-  [
-    'assert.includeMembers([1, 2, 3], [2, 1, 2]);',
-    'expect([1, 2, 3]).toEqual(expect.arrayContaining([2, 1, 2]));',
-  ],
-  [
-    'assert.notIncludeMembers([1, 2, 3], [5, 1]);',
-    'expect([1, 2, 3]).not.toEqual(expect.arrayContaining([5, 1]));',
-  ],
-  [
-    'assert.includeDeepMembers([{ a: 1 }, { b: 2 }, { c: 3 }], [{ b: 2 }, { a: 1 }, { b: 2 }]);',
-    'expect([{ a: 1 }, { b: 2 }, { c: 3 }]).toEqual(expect.arrayContaining([{ b: 2 }, { a: 1 }, { b: 2 }]));',
-  ],
-  [
-    'assert.notIncludeDeepMembers([{ a: 1 }, { b: 2 }, { c: 3 }], [{ b: 2 }, { f: 5 }]);',
-    'expect([{ a: 1 }, { b: 2 }, { c: 3 }]).not.toEqual(expect.arrayContaining([{ b: 2 }, { f: 5 }]));',
-  ],
-  ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],
-  ['assert.isNotExtensible(foo);', 'expect(Object.isExtensible(foo)).not.toBe(true);'],
-  ['assert.isSealed(foo);', 'expect(Object.isSealed(foo)).toBe(true);'],
-  ['assert.isNotSealed(foo);', 'expect(Object.isSealed(foo)).not.toBe(true);'],
-  ['assert.isFrozen(foo);', 'expect(Object.isFrozen(foo)).toBe(true);'],
-  ['assert.isNotFrozen(foo);', 'expect(Object.isFrozen(foo)).not.toBe(true);'],
-]
-
-const mappingTest = mappings.reduce(
-  (test, [assert, expect]) => ({
-    input: `
+describe('Mapping Test', () => {
+  const mappings = [
+    // follow the ordering here: http://chaijs.com/api/assert/
+    ['assert(foo === bar, baz);', 'expect(foo === bar).toBeTruthy();'],
+    ['assert(Array.isArray([]));', 'expect(Array.isArray([])).toBeTruthy();'],
+    ['assert.fail(foo, bar, baz);', 'expect(false).toBe(true);'],
+    ['assert.isOk(foo, msg);', 'expect(foo).toBeTruthy();'],
+    ['assert.isNotOk(foo);', 'expect(foo).toBeFalsy();'],
+    ['assert.equal(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+    ['assert.notEqual(foo, bar, baz);', 'expect(foo).not.toEqual(bar);'],
+    ['assert.strictEqual(foo, bar, baz);', 'expect(foo).toBe(bar);'],
+    ['assert.notStrictEqual(foo, bar, baz);', 'expect(foo).not.toBe(bar);'],
+    ['assert.deepEqual(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+    ['assert.notDeepEqual(foo, bar, baz);', 'expect(foo).not.toEqual(bar);'],
+    ['assert.isAbove(foo, bar, baz);', 'expect(foo).toBeGreaterThan(bar);'],
+    ['assert.isAtLeast(foo, bar, baz);', 'expect(foo).toBeGreaterThanOrEqual(bar);'],
+    ['assert.isBelow(foo, bar, baz);', 'expect(foo).toBeLessThan(bar);'],
+    ['assert.isAtMost(foo, bar, baz);', 'expect(foo).toBeLessThanOrEqual(bar);'],
+    ['assert.isTrue(foo);', 'expect(foo).toBe(true);'],
+    ['assert.isTrue(foo, msg);', 'expect(foo).toBe(true);'],
+    ['assert.isNotTrue(foo, msg);', 'expect(foo).not.toBe(true);'],
+    ['assert.isFalse(foo, msg);', 'expect(foo).toBe(false);'],
+    ['assert.isNotFalse(foo, msg);', 'expect(foo).not.toBe(false);'],
+    ['assert.isNull(foo, msg);', 'expect(foo).toBeNull();'],
+    ['assert.isNotNull(foo, msg);', 'expect(foo).not.toBeNull();'],
+    ['assert.isNaN(foo, msg);', 'expect(foo).toBe();'],
+    ['assert.isNotNaN(foo, msg);', 'expect(foo).not.toBe();'],
+    ['assert.isUndefined(foo, msg);', 'expect(foo).not.toBeDefined();'],
+    ['assert.isDefined(foo, msg);', 'expect(foo).toBeDefined();'],
+    ['assert.isFunction(foo, msg);', "expect(typeof foo).toBe('function');"],
+    ['assert.isNotFunction(foo, msg);', "expect(typeof foo).not.toBe('function');"],
+    ['assert.isObject(foo, msg);', "expect(typeof foo).toBe('object');"],
+    ['assert.isNotObject(foo, msg);', "expect(typeof foo).not.toBe('object');"],
+    ['assert.isArray(foo, msg);', 'expect(Array.isArray(foo)).toBe(true);'],
+    ['assert.isNotArray(foo, msg);', 'expect(Array.isArray(foo)).not.toBe(true);'],
+    ['assert.isString(foo, msg);', "expect(typeof foo).toBe('string');"],
+    ['assert.isNotString(foo, msg);', "expect(typeof foo).not.toBe('string');"],
+    ['assert.isNumber(foo, msg);', "expect(typeof foo).toBe('number');"],
+    ['assert.isNotNumber(foo, msg);', "expect(typeof foo).not.toBe('number');"],
+    ['assert.isBoolean(foo, msg);', "expect(typeof foo).toBe('boolean');"],
+    ['assert.isNotBoolean(foo, msg);', "expect(typeof foo).not.toBe('boolean');"],
+    ['assert.typeOf(foo, bar, baz);', 'expect(typeof foo).toBe(bar);'],
+    ['assert.notTypeOf(foo, bar, baz);', 'expect(typeof foo).not.toBe(bar);'],
+    ['assert.instanceOf(foo, bar, baz);', 'expect(foo).toBeInstanceOf(bar);'],
+    ['assert.notInstanceOf(foo, bar, baz);', 'expect(foo).not.toBeInstanceOf(bar);'],
+    ['assert.include(foo, bar, baz);', 'expect(foo).toContain(bar);'],
+    ['assert.notInclude(foo, bar, baz);', 'expect(foo).not.toContain(bar);'],
+    ['assert.match(foo, bar, baz);', 'expect(foo).toMatch(bar);'],
+    ['assert.notMatch(foo, bar, baz);', 'expect(foo).not.toMatch(bar);'],
+    ['assert.property(foo, bar, baz);', 'expect(bar in foo).toBeTruthy();'],
+    ['assert.notProperty(foo, bar, baz);', 'expect(bar in foo).toBeFalsy();'],
+    [
+      "assert.deepProperty({ tea: { green: 'matcha' }}, 'tea.green');",
+      "expect({ tea: { green: 'matcha' }}).toHaveProperty('tea.green');",
+    ],
+    [
+      "assert.notDeepProperty({ tea: { green: 'matcha' }}, 'tea.oolong');",
+      "expect({ tea: { green: 'matcha' }}).not.toHaveProperty('tea.oolong');",
+    ],
+    ['assert.propertyVal(foo, bar, baz);', 'expect(foo.bar).toBe(baz);'],
+    ['assert.propertyNotVal(foo, bar, baz);', 'expect(foo.bar).not.toBe(baz);'],
+    ['assert.notPropertyVal(foo, bar, baz);', 'expect(foo.bar).not.toBe(baz);'],
+    ['assert.nestedProperty(foo, bar);', 'expect(foo).toHaveProperty(bar);'],
+    ['assert.notNestedProperty(foo, bar);', 'expect(foo).not.toHaveProperty(bar);'],
+    ['assert.nestedPropertyVal(foo, bar, baz);', 'expect(foo).toHaveProperty(bar, baz);'],
+    [
+      'assert.notNestedPropertyVal(foo, bar, baz);',
+      'expect(foo).not.toHaveProperty(bar, baz);',
+    ],
+    [
+      "assert.deepPropertyVal({ tea: { green: 'matcha' } }, 'tea', { green: 'matcha' });",
+      "expect({ tea: { green: 'matcha' } }).toHaveProperty('tea', { green: 'matcha' });",
+    ],
+    [
+      "assert.notDeepPropertyVal({ tea: { green: 'matcha' } }, 'tea', { black: 'matcha' });",
+      "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('tea', { black: 'matcha' });",
+    ],
+    [
+      "assert.deepPropertyNotVal({ tea: { green: 'matcha' } }, 'tea', { green: 'oolong' });",
+      "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('tea', { green: 'oolong' });",
+    ],
+    [
+      "assert.notDeepPropertyVal({ tea: { green: 'matcha' } }, 'tea', { green: 'oolong' });",
+      "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('tea', { green: 'oolong' });",
+    ],
+    [
+      "assert.notDeepPropertyVal({ tea: { green: 'matcha' } }, 'coffee', { green: 'matcha' });",
+      "expect({ tea: { green: 'matcha' } }).not.toHaveProperty('coffee', { green: 'matcha' });",
+    ],
+    ['assert.lengthOf(foo, bar, baz);', 'expect(foo.length).toBe(bar);'],
+    ['assert.throws(foo, bar, baz);', 'expect(foo).toThrow();'],
+    ['assert.doesNotThrow(foo, bar, baz);', 'expect(foo).not.toThrow();'],
+    [
+      'assert.closeTo(foo, bar, baz, msg);',
+      'expect(Math.abs(foo - bar)).toBeLessThanOrEqual(baz);',
+    ],
+    [
+      'assert.approximately(foo, bar, baz);',
+      'expect(Math.abs(foo - bar)).toBeLessThanOrEqual(baz);',
+    ],
+    ['assert.sameMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+    ['assert.sameDeepMembers(foo, bar, baz);', 'expect(foo).toEqual(bar);'],
+    ['assert.ifError(foo);', 'expect(foo).toBeFalsy();'],
+    [
+      'assert.includeMembers([1, 2, 3], [2, 1, 2]);',
+      'expect([1, 2, 3]).toEqual(expect.arrayContaining([2, 1, 2]));',
+    ],
+    [
+      'assert.notIncludeMembers([1, 2, 3], [5, 1]);',
+      'expect([1, 2, 3]).not.toEqual(expect.arrayContaining([5, 1]));',
+    ],
+    [
+      'assert.includeDeepMembers([{ a: 1 }, { b: 2 }, { c: 3 }], [{ b: 2 }, { a: 1 }, { b: 2 }]);',
+      'expect([{ a: 1 }, { b: 2 }, { c: 3 }]).toEqual(expect.arrayContaining([{ b: 2 }, { a: 1 }, { b: 2 }]));',
+    ],
+    [
+      'assert.notIncludeDeepMembers([{ a: 1 }, { b: 2 }, { c: 3 }], [{ b: 2 }, { f: 5 }]);',
+      'expect([{ a: 1 }, { b: 2 }, { c: 3 }]).not.toEqual(expect.arrayContaining([{ b: 2 }, { f: 5 }]));',
+    ],
+    ['assert.isExtensible(foo);', 'expect(Object.isExtensible(foo)).toBe(true);'],
+    ['assert.isNotExtensible(foo);', 'expect(Object.isExtensible(foo)).not.toBe(true);'],
+    ['assert.isSealed(foo);', 'expect(Object.isSealed(foo)).toBe(true);'],
+    ['assert.isNotSealed(foo);', 'expect(Object.isSealed(foo)).not.toBe(true);'],
+    ['assert.isFrozen(foo);', 'expect(Object.isFrozen(foo)).toBe(true);'],
+    ['assert.isNotFrozen(foo);', 'expect(Object.isFrozen(foo)).not.toBe(true);'],
+  ]
+  const mappingTest = mappings.reduce(
+    (test, [assert, expect]) => ({
+      input: `
 ${test.input}
 ${assert}
 `,
-    output: `
+      output: `
 ${test.output}
 ${expect}
 `,
-  }),
-  {
-    input: `
+    }),
+    {
+      input: `
 // @flow
 import { assert } from 'chai';`,
-    output: `
+      output: `
 // @flow`,
-  }
-)
+    }
+  )
 
-testChanged('mappings', mappingTest.input, mappingTest.output)
+  test('mappings', () => {
+    assertTransformation(mappingTest.input, mappingTest.output)
+  })
 
-testChanged(
-  'mapping without import if skipImportDetection is set',
-  mappingTest.input.replace("import { assert } from 'chai';\n", ''),
-  mappingTest.output,
-  { skipImportDetection: true }
-)
+  test('mapping without import if skipImportDetection is set', () => {
+    assertTransformation(
+      mappingTest.input.replace("import { assert } from 'chai';\n", ''),
+      mappingTest.output,
+      { skipImportDetection: true }
+    )
+  })
+})
 
 test('not supported assertions', () => {
   const unsupportedAssertions = [
@@ -242,28 +247,30 @@ assert.${assertion}(foo, bar, baz);`,
   ])
 })
 
-testChanged(
-  'applies when chai default import used',
-  `
+test('applies when chai default import used', () => {
+  assertTransformation(
+    `
 // @flow
 import chai from 'chai';
 chai.assert.equal(foo, bar, baz);
 `,
-  `
+    `
 // @flow
 expect(foo).toEqual(bar);
 `
-)
+  )
+})
 
-testChanged(
-  'transforms renamed imports',
-  `
+test('transforms renamed imports', () => {
+  assertTransformation(
+    `
 // @flow
 import { assert as myCoolAssert } from 'chai';
 myCoolAssert.equal(foo, bar, baz);
 `,
-  `
+    `
 // @flow
 expect(foo).toEqual(bar);
 `
-)
+  )
+})

--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -13,17 +13,15 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(msg, source, expectedOutput) {
-  test(msg, () => {
-    const result = wrappedPlugin(source)
-    expect(result).toBe(expectedOutput)
-    expect(consoleWarnings).toEqual([])
-  })
+function assertTransformation(source, expectedOutput) {
+  const result = wrappedPlugin(source)
+  expect(result).toBe(expectedOutput)
+  expect(consoleWarnings).toEqual([])
 }
 
-testChanged(
-  'removes imports and does basic conversions of should and expect',
-  `
+test('removes imports and does basic conversions of should and expect', () => {
+  assertTransformation(
+    `
         var expect = require('chai').expect;
 
         describe('Instantiating TextField', () => {
@@ -33,7 +31,7 @@ testChanged(
             });
         });
     `,
-  `
+    `
         describe('Instantiating TextField', () => {
             it('should set the placeholder correctly', () => {
                 expect(textField.props.placeholder).toBe(PLACEHOLDER);
@@ -41,11 +39,12 @@ testChanged(
             });
         });
     `
-)
+  )
+})
 
-testChanged(
-  'removes imports and does basic conversions of should and expect',
-  `
+test('removes imports and does basic conversions of should and expect (2)', () => {
+  assertTransformation(
+    `
         const { expect } = require('chai');
         var should = require('chai').should();
 
@@ -68,7 +67,7 @@ testChanged(
             thing1.equal(thing2);
         });
     `,
-  `
+    `
         describe('Instantiating TextField', () => {
             it('should set the placeholder correctly', () => {
                 expect(textField.props.placeholder).toBe(PLACEHOLDER);
@@ -88,11 +87,12 @@ testChanged(
             thing1.equal(thing2);
         });
     `
-)
+  )
+})
 
-testChanged(
-  'removes imports (case where should is not assigned)',
-  `
+test('removes imports (case where should is not assigned)', () => {
+  assertTransformation(
+    `
         require('chai').should();
 
         describe('Instantiating TextField', () => {
@@ -101,31 +101,33 @@ testChanged(
               textField.props.placeholder.should.not.equal(PLACEHOLDER);
           });
         });`,
-  `
+    `
         describe('Instantiating TextField', () => {
           it('should set the placeholder correctly', () => {
               expect(textField.props.placeholder).toBe(PLACEHOLDER);
               expect(textField.props.placeholder).not.toBe(PLACEHOLDER);
           });
         });`
-)
+  )
+})
 
-testChanged(
-  'Removes complicated import',
-  `
+test('Removes complicated import', () => {
+  assertTransformation(
+    `
         const chai = require('chai');
         const expect = chai.expect;
 
         expect(foo).to.be.true;
     `,
-  `
+    `
         expect(foo).toBe(true);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "a-an"',
-  `
+test('converts "a-an"', () => {
+  assertTransformation(
+    `
         expect('test').to.be.a('string', 'error message');
         expect({ foo: 'bar' }).to.be.an('object');
         expect({ foo: 'bar' }).to.be.an(Object);
@@ -144,7 +146,7 @@ testChanged(
 
         'test'.should.be.a('string');
     `,
-  `
+    `
         expect(typeof 'test').toBe('string');
         expect({ foo: 'bar' }).toBeInstanceOf(Object);
         expect({ foo: 'bar' }).toBeInstanceOf(Object);
@@ -163,25 +165,27 @@ testChanged(
 
         expect(typeof 'test').toBe('string');
     `
-)
+  )
+})
 
-testChanged(
-  'converts "above"',
-  `
+test('converts "above"', () => {
+  assertTransformation(
+    `
         expect(10).to.be.above(5);
         expect(10).to.be.gt(5);
         expect(10).to.be.greaterThan(5);
     `,
-  `
+    `
         expect(10).toBeGreaterThan(5);
         expect(10).toBeGreaterThan(5);
         expect(10).toBeGreaterThan(5);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "below"',
-  `
+test('converts "below"', () => {
+  assertTransformation(
+    `
         expect(5).to.be.below(10);
         expect(5).to.be.below(10, 'error message');
         expect(3).to.be.at.below(5);
@@ -190,7 +194,7 @@ testChanged(
         (1).should.be.lessThan(5);
         (1).should.be.lt(5);
     `,
-  `
+    `
         expect(5).toBeLessThan(10);
         expect(5).toBeLessThan(10);
         expect(3).toBeLessThan(5);
@@ -199,11 +203,12 @@ testChanged(
         expect(1).toBeLessThan(5);
         expect(1).toBeLessThan(5);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "eql"',
-  `
+test('converts "eql"', () => {
+  assertTransformation(
+    `
         expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
         expect([1, 2, 3]).to.eql([1, 2, 3]);
         a.should.eql(a);
@@ -211,7 +216,7 @@ testChanged(
         expect("123").to.eql("123");
         expect("123").to.not.eql("123");
     `,
-  `
+    `
         expect({ foo: 'bar' }).toEqual({ foo: 'bar' });
         expect([1, 2, 3]).toEqual([1, 2, 3]);
         expect(a).toEqual(a);
@@ -219,11 +224,12 @@ testChanged(
         expect("123").toBe("123");
         expect("123").not.toBe("123");
     `
-)
+  )
+})
 
-testChanged(
-  'converts "equal"',
-  `
+test('converts "equal"', () => {
+  assertTransformation(
+    `
         expect('hello').to.equal('hello');
         expect('hello', 'some message here explaining hello').to.equal('hello');
         expect(42).to.equal(42);
@@ -234,7 +240,7 @@ testChanged(
         should.equal('foo', 'foo');
         should.not.equal('foo', 'bar');
     `,
-  `
+    `
         expect('hello').toBe('hello');
         // some message here explaining hello
         expect('hello').toBe('hello');
@@ -246,11 +252,12 @@ testChanged(
         expect('foo').toBe('foo');
         expect('foo').not.toBe('bar');
     `
-)
+  )
+})
 
-testChanged(
-  'converts "exist-defined"',
-  `
+test('converts "exist-defined"', () => {
+  assertTransformation(
+    `
         expect(foo).to.exist;
         expect(bar).to.not.exist;
         expect(baz).to.not.exist;
@@ -262,7 +269,7 @@ testChanged(
 
         should.exist('');
     `,
-  `
+    `
         expect(foo).toBeDefined();
         expect(bar).toBeFalsy();
         expect(baz).toBeFalsy();
@@ -274,175 +281,188 @@ testChanged(
 
         expect('').toBeDefined();
     `
-)
+  )
+})
 
-testChanged(
-  'converts "extensible"',
-  `
+test('converts "extensible"', () => {
+  assertTransformation(
+    `
         expect(nonExtensibleObject).to.not.be.extensible;
         expect({}).to.be.extensible;
         expect({}).to.be.extensible();
         x.should.be.extensible;
         x.should.be.extensible();
     `,
-  `
+    `
         expect(Object.isExtensible(nonExtensibleObject)).toBe(false);
         expect(Object.isExtensible({})).toBe(true);
         expect(Object.isExtensible({})).toBe(true);
         expect(Object.isExtensible(x)).toBe(true);
         expect(Object.isExtensible(x)).toBe(true);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "empty"',
-  `
+test('converts "empty"', () => {
+  assertTransformation(
+    `
         expect([]).to.be.empty;
         expect('').to.be.empty;
         expect(v).to.be.empty;
         expect({}).to.be.empty;
         expect(wrapper.find('.failure-message').length).to.be.empty;
   `,
-  `
+    `
         expect([]).toHaveLength(0);
         expect('').toHaveLength(0);
         expect(Object.keys(v)).toHaveLength(0);
         expect(Object.keys({})).toHaveLength(0);
         expect(wrapper.find('.failure-message')).toHaveLength(0);
   `
-)
+  )
+})
 
-testChanged(
-  'converts "false"',
-  `
+test('converts "false"', () => {
+  assertTransformation(
+    `
         expect(false).to.be.false;
         expect(0).to.not.be.false;
         expect(foo + bar).to.be.false;
     `,
-  `
+    `
         expect(false).toBe(false);
         expect(0).not.toBe(false);
         expect(foo + bar).toBe(false);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "finite"',
-  `
+test('converts "finite"', () => {
+  assertTransformation(
+    `
         (Infinity).should.not.be.finite;
         (-10).should.be.finite;
     `,
-  `
+    `
         expect(isFinite(Infinity)).toBe(false);
         expect(isFinite(-10)).toBe(true);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "frozen"',
-  `
+test('converts "frozen"', () => {
+  assertTransformation(
+    `
         expect(frozenObject).to.be.frozen;
         expect({}).to.not.be.frozen;
     `,
-  `
+    `
         expect(Object.isFrozen(frozenObject)).toBe(true);
         expect(Object.isFrozen({})).toBe(false);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "string"',
-  `
+test('converts "string"', () => {
+  assertTransformation(
+    `
         expect('foobar').to.have.string('bar');
         expect('foobar').not.to.have.string('z');
         expect(someString).to.have.string('bar');
         expect(someString).not.to.have.string('bar');
     `,
-  `
+    `
         expect('foobar').toContain('bar');
         expect('foobar').not.toContain('z');
         expect(someString).toContain('bar');
         expect(someString).not.toContain('bar');
     `
-)
+  )
+})
 
-testChanged(
-  'converts "includes-contains"',
-  `
+test('converts "includes-contains"', () => {
+  assertTransformation(
+    `
         expect('foobar').to.contain('foo');
         expect([1, 2, 3]).to.include(2);
         expect('foobar').which.contains('foo');
         expect({ foo: 1, bar: 2 }).to.contain({ bar: 2 });
     `,
-  `
+    `
         expect('foobar').toContain('foo');
         expect([1, 2, 3]).toEqual(expect.arrayContaining([2]));
         expect('foobar').toContain('foo');
         expect({ foo: 1, bar: 2 }).toMatchObject({ bar: 2 });
     `
-)
+  )
+})
 
-testChanged(
-  'converts chained "includes-contains"',
-  `
+test('converts chained "includes-contains"', () => {
+  assertTransformation(
+    `
         expect([1, 2, 3]).to.be.an('array').that.includes(2);
         expect(arr).to.be.an('array').that.does.not.include(3);
     `,
-  `
+    `
         expect([1, 2, 3]).toEqual(expect.arrayContaining([2]));
         expect(arr).toEqual(expect.not.arrayContaining([3]));
     `
-)
+  )
+})
 
-testChanged(
-  'converts empty array assertion',
-  `
+test('converts empty array assertion', () => {
+  assertTransformation(
+    `
         expect(arr).to.be.an('array').that.is.empty;
     `,
-  `
+    `
         expect(arr).toEqual([]);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "instanceof"',
-  `
+test('converts "instanceof"', () => {
+  assertTransformation(
+    `
         expect(foo).to.be.an.instanceof(Foo);
         expect(foo).not.to.be.an.instanceof(Foo);
         expect(123).to.be.instanceof(Number);
     `,
-  `
+    `
         expect(foo).toBeInstanceOf(Foo);
         expect(foo).not.toBeInstanceOf(Foo);
         expect(123).toBeInstanceOf(Number);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "keys"',
-  `
+test('converts "keys"', () => {
+  assertTransformation(
+    `
         expect([1, 2, 3]).to.have.all.keys(1, 2);
         expect({ foo: 1, bar: 2 }).to.have.all.keys({ bar: 6, foo: 7 });
         expect({ foo: 1, bar: 2, baz: 3 }).to.contain.all.keys(['bar', 'foo']);
         expect({ foo: 1, bar: 2, baz: 3 }).to.contain.all.keys({ bar: 6 });
     `,
-  `
+    `
         expect([1, 2, 3]).toEqual(expect.arrayContaining([1, 2]));
         expect(Object.keys({ foo: 1, bar: 2 })).toEqual(expect.arrayContaining(Object.keys({ bar: 6, foo: 7 })));
         expect(Object.keys({ foo: 1, bar: 2, baz: 3 })).toEqual(expect.arrayContaining(['bar', 'foo']));
         expect(Object.keys({ foo: 1, bar: 2, baz: 3 })).toEqual(expect.arrayContaining(Object.keys({ bar: 6 })));
     `
-)
+  )
+})
 
-testChanged(
-  'converts "least"',
-  `expect(10).to.be.at.least(10);`,
-  `expect(10).toBeGreaterThanOrEqual(10);`
-)
+test('converts "least"', () => {
+  assertTransformation(
+    `expect(10).to.be.at.least(10);`,
+    `expect(10).toBeGreaterThanOrEqual(10);`
+  )
+})
 
-testChanged(
-  'converts "length"',
-  `
+test('converts "length"', () => {
+  assertTransformation(
+    `
         expect('foo').to.have.length(3);
         expect([1,2]).to.have.length(2);
 
@@ -450,7 +470,7 @@ testChanged(
         expect([1,2]).to.have.length.of.at.most(4);
         expect(anArray).to.have.length.above(2);
     `,
-  `
+    `
         expect('foo').toHaveLength(3);
         expect([1,2]).toHaveLength(2);
 
@@ -458,31 +478,34 @@ testChanged(
         expect([1,2].length).toBeLessThanOrEqual(4);
         expect(anArray.length).toBeGreaterThan(2);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "lengthof"',
-  `
+test('converts "lengthof"', () => {
+  assertTransformation(
+    `
         expect([1, 2, 3]).to.have.lengthOf(3);
         expect('foobar').to.have.lengthOf(6);
         'test'.should.have.lengthOf(4);
     `,
-  `
+    `
         expect([1, 2, 3]).toHaveLength(3);
         expect('foobar').toHaveLength(6);
         expect('test').toHaveLength(4);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "match"',
-  `expect('foobar').to.match(/^foo/);`,
-  `expect('foobar').toMatch(/^foo/);`
-)
+test('converts "match"', () => {
+  assertTransformation(
+    `expect('foobar').to.match(/^foo/);`,
+    `expect('foobar').toMatch(/^foo/);`
+  )
+})
 
-testChanged(
-  'converts "members"',
-  `
+test('converts "members"', () => {
+  assertTransformation(
+    `
         expect([1, 2, 3]).to.include.members([3, 2]);
         expect([1, 2, 3]).to.not.include.members([3, 2, 8]);
 
@@ -493,7 +516,7 @@ testChanged(
 
         expect({ id: 1 }).to.include.members({ id: 1 });
     `,
-  `
+    `
         expect([1, 2, 3]).toEqual(expect.arrayContaining([3, 2]));
         expect([1, 2, 3]).not.toEqual(expect.arrayContaining([3, 2, 8]));
 
@@ -504,41 +527,42 @@ testChanged(
 
         expect({ id: 1 }).toEqual(expect.objectContaining({ id: 1 }));
     `
-)
+  )
+})
 
-testChanged(
-  'converts "most"',
-  `expect(5).to.be.at.most(5);`,
-  `expect(5).toBeLessThanOrEqual(5);`
-)
+test('converts "most"', () => {
+  assertTransformation(`expect(5).to.be.at.most(5);`, `expect(5).toBeLessThanOrEqual(5);`)
+})
 
-testChanged(
-  'converts "nan"',
-  `
+test('converts "nan"', () => {
+  assertTransformation(
+    `
         expect('foo').to.be.NaN;
         expect(4).not.to.be.NaN;
     `,
-  `
+    `
         expect('foo').toBeNaN();
         expect(4).not.toBeNaN();
     `
-)
+  )
+})
 
-testChanged(
-  'converts "null"',
-  `
+test('converts "null"', () => {
+  assertTransformation(
+    `
         expect(null).to.be.null;
         expect(undefined).to.not.be.null;
     `,
-  `
+    `
         expect(null).toBeNull();
         expect(undefined).not.toBeNull();
     `
-)
+  )
+})
 
-testChanged(
-  'converts "ok"',
-  `
+test('converts "ok"', () => {
+  assertTransformation(
+    `
         expect('everything').to.be.ok;
         expect(1).to.be.ok;
         expect(false).to.not.be.ok;
@@ -551,7 +575,7 @@ testChanged(
         expect(x.ok).toBeTruthy();
         expect(x.ok).to.be.ok;
         `,
-  `
+    `
         expect('everything').toBeTruthy();
         expect(1).toBeTruthy();
         expect(false).toBeFalsy();
@@ -564,57 +588,62 @@ testChanged(
         expect(x.ok).toBeTruthy();
         expect(x.ok).toBeTruthy();
         `
-)
+  )
+})
 
-testChanged(
-  'converts "ownproperty"',
-  `expect('test').to.have.ownProperty('length')`,
-  `expect('test'.hasOwnProperty('length')).toBeTruthy()`
-)
+test('converts "ownproperty"', () => {
+  assertTransformation(
+    `expect('test').to.have.ownProperty('length')`,
+    `expect('test'.hasOwnProperty('length')).toBeTruthy()`
+  )
+})
 
-testChanged(
-  'converts "ownpropertydescriptor"',
-  `
+test('converts "ownpropertydescriptor"', () => {
+  assertTransformation(
+    `
         expect('test').to.have.ownPropertyDescriptor('length');
         expect('test').to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
         expect('test').not.to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 3 });
     `,
-  `
+    `
         expect(Object.getOwnPropertyDescriptor('test', 'length')).not.toBeUndefined();
         expect(Object.getOwnPropertyDescriptor('test', 'length')).toEqual({ enumerable: false, configurable: false, writable: false, value: 4 });
         expect(Object.getOwnPropertyDescriptor('test', 'length')).toEqual({ enumerable: false, configurable: false, writable: false, value: 3 });
     `
-)
+  )
+})
 
-testChanged(
-  'converts "property"',
-  `
+test('converts "property"', () => {
+  assertTransformation(
+    `
         expect(deepObj).to.have.deep.property("green.tea", "matcha");
         expect(obj).to.have.property("foo");
         expect(obj).to.have.property("foo", "bar");
     `,
-  `
+    `
         expect(deepObj).toHaveProperty("green.tea", "matcha");
         expect(obj).toHaveProperty("foo");
         expect(obj).toHaveProperty("foo", "bar");
     `
-)
+  )
+})
 
-testChanged(
-  'converts "sealed"',
-  `
+test('converts "sealed"', () => {
+  assertTransformation(
+    `
         expect(sealedObject).to.be.sealed;
         expect({}).to.not.be.sealed;
     `,
-  `
+    `
         expect(Object.isSealed(sealedObject)).toBe(true);
         expect(Object.isSealed({})).toBe(false);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "throw"',
-  `
+test('converts "throw"', () => {
+  assertTransformation(
+    `
         const err = new ReferenceError('This is a bad function.');
         const fn = function() { throw err; };
         expect(fn).to.throw(ReferenceError);
@@ -624,7 +653,7 @@ testChanged(
         expect(fn).to.throw(ReferenceError, /bad function/);
         expect(fn).to.throw(err);
     `,
-  `
+    `
         const err = new ReferenceError('This is a bad function.');
         const fn = function() { throw err; };
         expect(fn).toThrowError(ReferenceError);
@@ -634,49 +663,53 @@ testChanged(
         expect(fn).toThrowError(ReferenceError);
         expect(fn).toThrowError(err);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "true"',
-  `
+test('converts "true"', () => {
+  assertTransformation(
+    `
         expect(true).to.be.true;
         expect(1).to.not.be.true;
         expect(true).to.be.true();
     `,
-  `
+    `
         expect(true).toBe(true);
         expect(1).not.toBe(true);
         expect(true).toBe(true);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "undefined"',
-  `
+test('converts "undefined"', () => {
+  assertTransformation(
+    `
         expect(undefined).to.be.undefined;
         expect(undefined).to.equal(undefined);
         expect(null).to.not.be.undefined;
         expect(null).to.not.be.undefined();
         expect(null).to.not.equal(undefined);
     `,
-  `
+    `
         expect(undefined).toBeUndefined();
         expect(undefined).toBeUndefined();
         expect(null).toBeDefined();
         expect(null).toBeDefined();
         expect(null).toBeDefined();
     `
-)
+  )
+})
 
-testChanged(
-  'converts "function"',
-  `
+test('converts "function"', () => {
+  assertTransformation(
+    `
         expect(foo).to.be.a.function;
     `,
-  `
+    `
         expect(foo).toBeInstanceOf(Function);
     `
-)
+  )
+})
 
 it('warns about using chai extensions', () => {
   wrappedPlugin(`
@@ -690,27 +723,28 @@ it('warns about using chai extensions', () => {
   ])
 })
 
-testChanged(
-  'does not convert "empty"',
-  `
+test('does not convert "empty"', () => {
+  assertTransformation(
+    `
         expect(foo.empty).to.be.undefined;
         const foo = rx.Observable.empty;
     `,
-  `
+    `
         expect(foo.empty).toBeUndefined();
         const foo = rx.Observable.empty;
     `
-)
+  )
+})
 
-testChanged(
-  'removes params to expect() except for the first',
-  `
+test('removes params to expect() except for the first', () => {
+  assertTransformation(
+    `
         expect(foo, 'Expected foo to be defined').to.exist;
         expect(foo, 'Expected foo to be defined').to.equal(true);
         expect(foo, \`Expected foo to be defined for \${id}\`).to.be.defined;
         expect(foo, 'Expected ' + foo + ' to be defined').to.equal(true);
     `,
-  `
+    `
         // Expected foo to be defined
         expect(foo).toBeDefined();
         // Expected foo to be defined
@@ -720,26 +754,28 @@ testChanged(
         // 'Expected ' + foo + ' to be defined'
         expect(foo).toBe(true);
     `
-)
+  )
+})
 
-testChanged(
-  'converts equal(null) to toBeNull()',
-  `
+test('converts equal(null) to toBeNull()', () => {
+  assertTransformation(
+    `
         expect(actual).to.equal(null);
     `,
-  `
+    `
         expect(actual).toBeNull();
     `
-)
+  )
+})
 
-testChanged(
-  'converts "within"',
-  `
+test('converts "within"', () => {
+  assertTransformation(
+    `
         expect(7).to.be.within(5, 10);
 
         (5).should.be.within(2, 4);
     `,
-  `
+    `
         expect(7).toBeGreaterThanOrEqual(5);
         expect(7).toBeLessThanOrEqual(10);
 
@@ -747,18 +783,19 @@ testChanged(
 
         expect(5).toBeLessThanOrEqual(4);
     `
-)
+  )
+})
 
-testChanged(
-  'converts "within" with length',
-  `
+test('converts "within" with length', () => {
+  assertTransformation(
+    `
         expect('foo').to.have.length.within(2, 4);
 
         expect([1, 2, 3]).to.have.length.within(2, 4);
 
         expect('foo').to.have.length.within(2, 4, 'error message');
     `,
-  `
+    `
         expect('foo'.length).toBeGreaterThanOrEqual(2);
         expect('foo'.length).toBeLessThanOrEqual(4);
 
@@ -770,7 +807,8 @@ testChanged(
 
         expect('foo'.length).toBeLessThanOrEqual(4);
     `
-)
+  )
+})
 
 it('warns about not supported assertions part 1', () => {
   wrappedPlugin(`

--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -13,14 +13,14 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function assertTransformation(source, expectedOutput) {
+function expectTransformation(source, expectedOutput) {
   const result = wrappedPlugin(source)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
 }
 
 test('removes imports and does basic conversions of should and expect', () => {
-  assertTransformation(
+  expectTransformation(
     `
         var expect = require('chai').expect;
 
@@ -43,7 +43,7 @@ test('removes imports and does basic conversions of should and expect', () => {
 })
 
 test('removes imports and does basic conversions of should and expect (2)', () => {
-  assertTransformation(
+  expectTransformation(
     `
         const { expect } = require('chai');
         var should = require('chai').should();
@@ -91,7 +91,7 @@ test('removes imports and does basic conversions of should and expect (2)', () =
 })
 
 test('removes imports (case where should is not assigned)', () => {
-  assertTransformation(
+  expectTransformation(
     `
         require('chai').should();
 
@@ -112,7 +112,7 @@ test('removes imports (case where should is not assigned)', () => {
 })
 
 test('Removes complicated import', () => {
-  assertTransformation(
+  expectTransformation(
     `
         const chai = require('chai');
         const expect = chai.expect;
@@ -126,7 +126,7 @@ test('Removes complicated import', () => {
 })
 
 test('converts "a-an"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('test').to.be.a('string', 'error message');
         expect({ foo: 'bar' }).to.be.an('object');
@@ -169,7 +169,7 @@ test('converts "a-an"', () => {
 })
 
 test('converts "above"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(10).to.be.above(5);
         expect(10).to.be.gt(5);
@@ -184,7 +184,7 @@ test('converts "above"', () => {
 })
 
 test('converts "below"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(5).to.be.below(10);
         expect(5).to.be.below(10, 'error message');
@@ -207,7 +207,7 @@ test('converts "below"', () => {
 })
 
 test('converts "eql"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
         expect([1, 2, 3]).to.eql([1, 2, 3]);
@@ -228,7 +228,7 @@ test('converts "eql"', () => {
 })
 
 test('converts "equal"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('hello').to.equal('hello');
         expect('hello', 'some message here explaining hello').to.equal('hello');
@@ -256,7 +256,7 @@ test('converts "equal"', () => {
 })
 
 test('converts "exist-defined"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(foo).to.exist;
         expect(bar).to.not.exist;
@@ -285,7 +285,7 @@ test('converts "exist-defined"', () => {
 })
 
 test('converts "extensible"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(nonExtensibleObject).to.not.be.extensible;
         expect({}).to.be.extensible;
@@ -304,7 +304,7 @@ test('converts "extensible"', () => {
 })
 
 test('converts "empty"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect([]).to.be.empty;
         expect('').to.be.empty;
@@ -323,7 +323,7 @@ test('converts "empty"', () => {
 })
 
 test('converts "false"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(false).to.be.false;
         expect(0).to.not.be.false;
@@ -338,7 +338,7 @@ test('converts "false"', () => {
 })
 
 test('converts "finite"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         (Infinity).should.not.be.finite;
         (-10).should.be.finite;
@@ -351,7 +351,7 @@ test('converts "finite"', () => {
 })
 
 test('converts "frozen"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(frozenObject).to.be.frozen;
         expect({}).to.not.be.frozen;
@@ -364,7 +364,7 @@ test('converts "frozen"', () => {
 })
 
 test('converts "string"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('foobar').to.have.string('bar');
         expect('foobar').not.to.have.string('z');
@@ -381,7 +381,7 @@ test('converts "string"', () => {
 })
 
 test('converts "includes-contains"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('foobar').to.contain('foo');
         expect([1, 2, 3]).to.include(2);
@@ -398,7 +398,7 @@ test('converts "includes-contains"', () => {
 })
 
 test('converts chained "includes-contains"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect([1, 2, 3]).to.be.an('array').that.includes(2);
         expect(arr).to.be.an('array').that.does.not.include(3);
@@ -411,7 +411,7 @@ test('converts chained "includes-contains"', () => {
 })
 
 test('converts empty array assertion', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(arr).to.be.an('array').that.is.empty;
     `,
@@ -422,7 +422,7 @@ test('converts empty array assertion', () => {
 })
 
 test('converts "instanceof"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(foo).to.be.an.instanceof(Foo);
         expect(foo).not.to.be.an.instanceof(Foo);
@@ -437,7 +437,7 @@ test('converts "instanceof"', () => {
 })
 
 test('converts "keys"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect([1, 2, 3]).to.have.all.keys(1, 2);
         expect({ foo: 1, bar: 2 }).to.have.all.keys({ bar: 6, foo: 7 });
@@ -454,14 +454,14 @@ test('converts "keys"', () => {
 })
 
 test('converts "least"', () => {
-  assertTransformation(
+  expectTransformation(
     `expect(10).to.be.at.least(10);`,
     `expect(10).toBeGreaterThanOrEqual(10);`
   )
 })
 
 test('converts "length"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('foo').to.have.length(3);
         expect([1,2]).to.have.length(2);
@@ -482,7 +482,7 @@ test('converts "length"', () => {
 })
 
 test('converts "lengthof"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect([1, 2, 3]).to.have.lengthOf(3);
         expect('foobar').to.have.lengthOf(6);
@@ -497,14 +497,14 @@ test('converts "lengthof"', () => {
 })
 
 test('converts "match"', () => {
-  assertTransformation(
+  expectTransformation(
     `expect('foobar').to.match(/^foo/);`,
     `expect('foobar').toMatch(/^foo/);`
   )
 })
 
 test('converts "members"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect([1, 2, 3]).to.include.members([3, 2]);
         expect([1, 2, 3]).to.not.include.members([3, 2, 8]);
@@ -531,11 +531,11 @@ test('converts "members"', () => {
 })
 
 test('converts "most"', () => {
-  assertTransformation(`expect(5).to.be.at.most(5);`, `expect(5).toBeLessThanOrEqual(5);`)
+  expectTransformation(`expect(5).to.be.at.most(5);`, `expect(5).toBeLessThanOrEqual(5);`)
 })
 
 test('converts "nan"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('foo').to.be.NaN;
         expect(4).not.to.be.NaN;
@@ -548,7 +548,7 @@ test('converts "nan"', () => {
 })
 
 test('converts "null"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(null).to.be.null;
         expect(undefined).to.not.be.null;
@@ -561,7 +561,7 @@ test('converts "null"', () => {
 })
 
 test('converts "ok"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('everything').to.be.ok;
         expect(1).to.be.ok;
@@ -592,14 +592,14 @@ test('converts "ok"', () => {
 })
 
 test('converts "ownproperty"', () => {
-  assertTransformation(
+  expectTransformation(
     `expect('test').to.have.ownProperty('length')`,
     `expect('test'.hasOwnProperty('length')).toBeTruthy()`
   )
 })
 
 test('converts "ownpropertydescriptor"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('test').to.have.ownPropertyDescriptor('length');
         expect('test').to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
@@ -614,7 +614,7 @@ test('converts "ownpropertydescriptor"', () => {
 })
 
 test('converts "property"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(deepObj).to.have.deep.property("green.tea", "matcha");
         expect(obj).to.have.property("foo");
@@ -629,7 +629,7 @@ test('converts "property"', () => {
 })
 
 test('converts "sealed"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(sealedObject).to.be.sealed;
         expect({}).to.not.be.sealed;
@@ -642,7 +642,7 @@ test('converts "sealed"', () => {
 })
 
 test('converts "throw"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         const err = new ReferenceError('This is a bad function.');
         const fn = function() { throw err; };
@@ -667,7 +667,7 @@ test('converts "throw"', () => {
 })
 
 test('converts "true"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(true).to.be.true;
         expect(1).to.not.be.true;
@@ -682,7 +682,7 @@ test('converts "true"', () => {
 })
 
 test('converts "undefined"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(undefined).to.be.undefined;
         expect(undefined).to.equal(undefined);
@@ -701,7 +701,7 @@ test('converts "undefined"', () => {
 })
 
 test('converts "function"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(foo).to.be.a.function;
     `,
@@ -724,7 +724,7 @@ it('warns about using chai extensions', () => {
 })
 
 test('does not convert "empty"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(foo.empty).to.be.undefined;
         const foo = rx.Observable.empty;
@@ -737,7 +737,7 @@ test('does not convert "empty"', () => {
 })
 
 test('removes params to expect() except for the first', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(foo, 'Expected foo to be defined').to.exist;
         expect(foo, 'Expected foo to be defined').to.equal(true);
@@ -758,7 +758,7 @@ test('removes params to expect() except for the first', () => {
 })
 
 test('converts equal(null) to toBeNull()', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(actual).to.equal(null);
     `,
@@ -769,7 +769,7 @@ test('converts equal(null) to toBeNull()', () => {
 })
 
 test('converts "within"', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect(7).to.be.within(5, 10);
 
@@ -787,7 +787,7 @@ test('converts "within"', () => {
 })
 
 test('converts "within" with length', () => {
-  assertTransformation(
+  expectTransformation(
     `
         expect('foo').to.have.length.within(2, 4);
 

--- a/src/transformers/expect-js.test.ts
+++ b/src/transformers/expect-js.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function assertTransformation(source, expectedOutput, options = {}) {
+function expectTransformation(source, expectedOutput, options = {}) {
   const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
@@ -23,7 +23,7 @@ function assertTransformation(source, expectedOutput, options = {}) {
 }
 
 test('does not touch code without expect require/import', () => {
-  assertTransformation(
+  expectTransformation(
     `
     const test = require("testlib");
     test(t => {
@@ -40,7 +40,7 @@ test('does not touch code without expect require/import', () => {
 })
 
 test('changes code without expect require/import if skipImportDetection is set', () => {
-  assertTransformation(
+  expectTransformation(
     `
     test(t => {
       expect(stuff).to.be.ok();
@@ -56,7 +56,7 @@ test('changes code without expect require/import if skipImportDetection is set',
 })
 
 test('maps expect matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -105,7 +105,7 @@ test('maps expect matchers', () => {
 })
 
 test('does not map non expect.js matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -124,7 +124,7 @@ test('does not map non expect.js matchers', () => {
 })
 
 test('maps expect not matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -163,7 +163,7 @@ test('maps expect not matchers', () => {
 })
 
 test('maps expect number matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -190,7 +190,7 @@ test('maps expect number matchers', () => {
 })
 
 test('maps expect throw matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -253,7 +253,7 @@ test('maps expect throw matchers', () => {
 })
 
 test('maps expect fail matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -270,7 +270,7 @@ test('maps expect fail matchers', () => {
 })
 
 test('maps expect a and an matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -319,7 +319,7 @@ test('maps expect a and an matchers', () => {
 })
 
 test('maps expect within matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
 
@@ -349,7 +349,7 @@ test('warns about unsupported matchers', () => {
 })
 
 test('standaloneMode: keeps Jest expect import', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect.js';
     import exp from 'expect';

--- a/src/transformers/expect-js.test.ts
+++ b/src/transformers/expect-js.test.ts
@@ -13,51 +13,51 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(msg, source, expectedOutput, options = {}) {
-  test(msg, () => {
-    const result = wrappedPlugin(source, options)
-    expect(result).toBe(expectedOutput)
-    expect(consoleWarnings).toEqual([])
+function assertTransformation(source, expectedOutput, options = {}) {
+  const result = wrappedPlugin(source, options)
+  expect(result).toBe(expectedOutput)
+  expect(consoleWarnings).toEqual([])
 
-    // Running it twice should yield same result
-    expect(wrappedPlugin(result, options)).toBe(result)
-  })
+  // Running it twice should yield same result
+  expect(wrappedPlugin(result, options)).toBe(result)
 }
 
-testChanged(
-  'does not touch code without expect require/import',
-  `
+test('does not touch code without expect require/import', () => {
+  assertTransformation(
+    `
     const test = require("testlib");
     test(t => {
       expect(stuff).to.be.ok();
     })
     `,
-  `
+    `
     const test = require("testlib");
     test(t => {
       expect(stuff).to.be.ok();
     })
     `
-)
+  )
+})
 
-testChanged(
-  'changes code without expect require/import if skipImportDetection is set',
-  `
+test('changes code without expect require/import if skipImportDetection is set', () => {
+  assertTransformation(
+    `
     test(t => {
       expect(stuff).to.be.ok();
     })
     `,
-  `
+    `
     test(t => {
       expect(stuff).toBeTruthy();
     })
     `,
-  { skipImportDetection: true }
-)
+    { skipImportDetection: true }
+  )
+})
 
-testChanged(
-  'maps expect matchers',
-  `
+test('maps expect matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
@@ -80,7 +80,7 @@ testChanged(
       expect(stuff).to.match('message');
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toBeTruthy();
       expect(stuff).toBeFalsy();
@@ -101,11 +101,12 @@ testChanged(
       expect(stuff).toMatch('message');
     });
     `
-)
+  )
+})
 
-testChanged(
-  'does not map non expect.js matchers',
-  `
+test('does not map non expect.js matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
@@ -113,17 +114,18 @@ testChanged(
       expect(stuff).to.be.bananas();
     });
     `,
-  `
+    `
     test(() => {
       bob(stuff).to.be.ok();
       expect(stuff).to.be.bananas();
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect not matchers',
-  `
+test('maps expect not matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
@@ -141,7 +143,7 @@ testChanged(
       expect(stuff).to.not.match('message');
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).not.toBe('message');
       expect(stuff).not.toBe('message');
@@ -157,11 +159,12 @@ testChanged(
       expect(stuff).not.toMatch('message');
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect number matchers',
-  `
+test('maps expect number matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
@@ -173,7 +176,7 @@ testChanged(
       expect(stuff).to.be.gt(42);
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toBeLessThan(42);
       expect(stuff).toBeLessThan(42);
@@ -183,11 +186,12 @@ testChanged(
       expect(stuff).toBeGreaterThan(42);
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect throw matchers',
-  `
+test('maps expect throw matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
@@ -210,7 +214,7 @@ testChanged(
       });
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toThrowError(Error);
       expect(stuff).toThrow();
@@ -245,27 +249,29 @@ testChanged(
       }
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect fail matchers',
-  `
+test('maps expect fail matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
       expect().fail('message');
     });
     `,
-  `
+    `
     test(() => {
       throw Error('message');
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect a and an matchers',
-  `
+test('maps expect a and an matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
@@ -288,7 +294,7 @@ testChanged(
       expect(stuff).to.be.an(Thing);
     });
     `,
-  `
+    `
     test(() => {
       expect(typeof stuff).toBe('function');
       expect(typeof stuff).toBe('string');
@@ -309,23 +315,25 @@ testChanged(
       expect(stuff).toBeInstanceOf(Thing);
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect within matchers',
-  `
+test('maps expect within matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
 
     test(() => {
       expect(stuff).to.be.within(0, 100);
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff > 0 && stuff < 100).toBeTruthy();
     });
     `
-)
+  )
+})
 
 test('warns about unsupported matchers', () => {
   wrappedPlugin(`
@@ -340,9 +348,9 @@ test('warns about unsupported matchers', () => {
   ])
 })
 
-testChanged(
-  'standaloneMode: keeps Jest expect import',
-  `
+test('standaloneMode: keeps Jest expect import', () => {
+  assertTransformation(
+    `
     import expect from 'expect.js';
     import exp from 'expect';
 
@@ -350,14 +358,15 @@ testChanged(
       expect(stuff).to.be('message');
     });
     `,
-  `
+    `
     import exp from 'expect';
 
     test(() => {
       expect(stuff).toBe('message');
     });
     `,
-  {
-    standaloneMode: true,
-  }
-)
+    {
+      standaloneMode: true,
+    }
+  )
+})

--- a/src/transformers/expect.test.ts
+++ b/src/transformers/expect.test.ts
@@ -13,51 +13,51 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(msg, source, expectedOutput, options = {}) {
-  test(msg, () => {
-    const result = wrappedPlugin(source, options)
-    expect(result).toBe(expectedOutput)
-    expect(consoleWarnings).toEqual([])
+function assertTransformation(source, expectedOutput, options = {}) {
+  const result = wrappedPlugin(source, options)
+  expect(result).toBe(expectedOutput)
+  expect(consoleWarnings).toEqual([])
 
-    // Running it twice should yield same result
-    expect(wrappedPlugin(result, options)).toBe(result)
-  })
+  // Running it twice should yield same result
+  expect(wrappedPlugin(result, options)).toBe(result)
 }
 
-testChanged(
-  'does not touch code without expect require/import',
-  `
+test('does not touch code without expect require/import', () => {
+  assertTransformation(
+    `
     const test = require("testlib");
     test(t => {
       expect(stuff).toExist();
     })
     `,
-  `
+    `
     const test = require("testlib");
     test(t => {
       expect(stuff).toExist();
     })
     `
-)
+  )
+})
 
-testChanged(
-  'changes code without expect require/import if skipImportDetection is set',
-  `
+test('changes code without expect require/import if skipImportDetection is set', () => {
+  assertTransformation(
+    `
     test(t => {
       expect(stuff).toExist();
     })
     `,
-  `
+    `
     test(t => {
       expect(stuff).toBeTruthy();
     })
     `,
-  { skipImportDetection: true }
-)
+    { skipImportDetection: true }
+  )
+})
 
-testChanged(
-  'maps expect matchers',
-  `
+test('maps expect matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -113,7 +113,7 @@ testChanged(
       expect(stuff).toHaveBeenCalledWith('foo', 'bar');
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toBeTruthy();
       expect(stuff).toBeTruthy();
@@ -167,11 +167,12 @@ testChanged(
       expect(stuff).toHaveBeenCalledWith('foo', 'bar');
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect number matchers',
-  `
+test('maps expect number matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -182,7 +183,7 @@ testChanged(
       expect(stuff).toBeGreaterThanOrEqualTo(42);
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toBeLessThan(42);
       expect(stuff).toBeLessThan(42);
@@ -191,11 +192,12 @@ testChanged(
       expect(stuff).toBeGreaterThanOrEqual(42);
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect contain matchers',
-  `
+test('maps expect contain matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -212,7 +214,7 @@ testChanged(
       expect({ a: 1, b: 2 }).toExcludeKeys([ 'c', 'd' ]);
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toContain(1);
       expect(stuff).toContain(1);
@@ -231,11 +233,12 @@ testChanged(
       });
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps expect spy matchers',
-  `
+test('maps expect spy matchers', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -244,18 +247,19 @@ testChanged(
       expect(stuff).toHaveBeenCalledWith('foo', 'bar');
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toHaveBeenCalled();
       expect(stuff).not.toHaveBeenCalled();
       expect(stuff).toHaveBeenCalledWith('foo', 'bar');
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps spy creation calls',
-  `
+test('maps spy creation calls', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -274,7 +278,7 @@ testChanged(
       not.a.spy.andCall(fn);
     });
     `,
-  `
+    `
     test(() => {
       var spy1 = jest.fn();
       var spy2 = jest.spyOn(video, 'play');
@@ -293,11 +297,12 @@ testChanged(
       not.a.spy.andCall(fn);
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps spy methods on intitialized spies',
-  `
+test('maps spy methods on intitialized spies', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -323,7 +328,7 @@ testChanged(
       spy2.reset();
     });
     `,
-  `
+    `
     test(() => {
       var spy1 = jest.fn();
       var spy2 = jest.spyOn(video, 'play');
@@ -349,11 +354,12 @@ testChanged(
       spy2.mockClear();
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps spy methods on intitialized spies (spread import)',
-  `
+test('maps spy methods on intitialized spies (spread import)', () => {
+  assertTransformation(
+    `
     import { createSpy, spyOn } from 'expect'
 
     test(() => {
@@ -365,7 +371,7 @@ testChanged(
       spy2.reset();
     });
     `,
-  `
+    `
     test(() => {
       var spy1 = jest.fn();
       var spy2 = jest.spyOn(video, 'play');
@@ -375,11 +381,12 @@ testChanged(
       spy2.mockClear();
     });
     `
-)
+  )
+})
 
-testChanged(
-  'maps spy array',
-  `
+test('maps spy array', () => {
+  assertTransformation(
+    `
     import { createSpy, spyOn } from 'expect'
 
     test(() => {
@@ -393,7 +400,7 @@ testChanged(
       expect(inputs[1].calls.length).toEqual(1)
     });
     `,
-  `
+    `
     test(() => {
       const inputs = [
         jest.fn(props => <input {...props.input} />),
@@ -405,11 +412,12 @@ testChanged(
       expect(inputs[1].mock.calls.length).toEqual(1)
     });
     `
-)
+  )
+})
 
-testChanged(
-  'renames non standard expect import name',
-  `
+test('renames non standard expect import name', () => {
+  assertTransformation(
+    `
     import exp from 'expect';
 
     test(() => {
@@ -418,18 +426,19 @@ testChanged(
       exp(stuff).toHaveBeenCalledWith(1);
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toHaveBeenCalled();
       expect(stuff).not.toHaveBeenCalled();
       expect(stuff).toHaveBeenCalledWith(1);
     });
     `
-)
+  )
+})
 
-testChanged(
-  'support chaining',
-  `
+test('support chaining', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -440,7 +449,7 @@ testChanged(
          .toBeMoreThan(42);
     });
     `,
-  `
+    `
     test(() => {
       expect(stuff).toBeTruthy();
       expect(typeof stuff).toBe('number');
@@ -448,32 +457,34 @@ testChanged(
       expect(stuff).toBeGreaterThan(42);
     });
     `
-)
+  )
+})
 
-testChanged(
-  'standaloneMode: keeps expect import',
-  `
+test('standaloneMode: keeps expect import', () => {
+  assertTransformation(
+    `
     import exp from 'expect';
 
     test(() => {
       exp(stuff).toHaveBeenCalled();
     });
     `,
-  `
+    `
     import exp from 'expect';
 
     test(() => {
       exp(stuff).toHaveBeenCalled();
     });
     `,
-  {
-    standaloneMode: true,
-  }
-)
+    {
+      standaloneMode: true,
+    }
+  )
+})
 
-testChanged(
-  'standaloneMode: rewrites expect.spyOn (import)',
-  `
+test('standaloneMode: rewrites expect.spyOn (import)', () => {
+  assertTransformation(
+    `
     import expect from 'expect';
 
     test(() => {
@@ -485,7 +496,7 @@ testChanged(
         expect(spy1.calls.length).toEqual(3);
     });
     `,
-  `
+    `
     import mock from 'jest-mock';
     import expect from 'expect';
 
@@ -498,14 +509,15 @@ testChanged(
         expect(spy1.mock.calls.length).toEqual(3);
     });
     `,
-  {
-    standaloneMode: true,
-  }
-)
+    {
+      standaloneMode: true,
+    }
+  )
+})
 
-testChanged(
-  'standaloneMode: rewrites expect.spyOn (require)',
-  `
+test('standaloneMode: rewrites expect.spyOn (require)', () => {
+  assertTransformation(
+    `
     const expect = require('expect');
 
     test(() => {
@@ -514,7 +526,7 @@ testChanged(
         expect(spy1.calls.length).toEqual(3);
     });
     `,
-  `
+    `
     const mock = require('jest-mock');
     const expect = require('expect');
 
@@ -524,10 +536,11 @@ testChanged(
         expect(spy1.mock.calls.length).toEqual(3);
     });
     `,
-  {
-    standaloneMode: true,
-  }
-)
+    {
+      standaloneMode: true,
+    }
+  )
+})
 
 test('warns about unsupported spy features', () => {
   wrappedPlugin(`

--- a/src/transformers/expect.test.ts
+++ b/src/transformers/expect.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function assertTransformation(source, expectedOutput, options = {}) {
+function expectTransformation(source, expectedOutput, options = {}) {
   const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
@@ -23,7 +23,7 @@ function assertTransformation(source, expectedOutput, options = {}) {
 }
 
 test('does not touch code without expect require/import', () => {
-  assertTransformation(
+  expectTransformation(
     `
     const test = require("testlib");
     test(t => {
@@ -40,7 +40,7 @@ test('does not touch code without expect require/import', () => {
 })
 
 test('changes code without expect require/import if skipImportDetection is set', () => {
-  assertTransformation(
+  expectTransformation(
     `
     test(t => {
       expect(stuff).toExist();
@@ -56,7 +56,7 @@ test('changes code without expect require/import if skipImportDetection is set',
 })
 
 test('maps expect matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -171,7 +171,7 @@ test('maps expect matchers', () => {
 })
 
 test('maps expect number matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -196,7 +196,7 @@ test('maps expect number matchers', () => {
 })
 
 test('maps expect contain matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -237,7 +237,7 @@ test('maps expect contain matchers', () => {
 })
 
 test('maps expect spy matchers', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -258,7 +258,7 @@ test('maps expect spy matchers', () => {
 })
 
 test('maps spy creation calls', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -301,7 +301,7 @@ test('maps spy creation calls', () => {
 })
 
 test('maps spy methods on intitialized spies', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -358,7 +358,7 @@ test('maps spy methods on intitialized spies', () => {
 })
 
 test('maps spy methods on intitialized spies (spread import)', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import { createSpy, spyOn } from 'expect'
 
@@ -385,7 +385,7 @@ test('maps spy methods on intitialized spies (spread import)', () => {
 })
 
 test('maps spy array', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import { createSpy, spyOn } from 'expect'
 
@@ -416,7 +416,7 @@ test('maps spy array', () => {
 })
 
 test('renames non standard expect import name', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import exp from 'expect';
 
@@ -437,7 +437,7 @@ test('renames non standard expect import name', () => {
 })
 
 test('support chaining', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -461,7 +461,7 @@ test('support chaining', () => {
 })
 
 test('standaloneMode: keeps expect import', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import exp from 'expect';
 
@@ -483,7 +483,7 @@ test('standaloneMode: keeps expect import', () => {
 })
 
 test('standaloneMode: rewrites expect.spyOn (import)', () => {
-  assertTransformation(
+  expectTransformation(
     `
     import expect from 'expect';
 
@@ -516,7 +516,7 @@ test('standaloneMode: rewrites expect.spyOn (import)', () => {
 })
 
 test('standaloneMode: rewrites expect.spyOn (require)', () => {
-  assertTransformation(
+  expectTransformation(
     `
     const expect = require('expect');
 

--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 })
 
 test('spyOn', () => {
-  assertTransformation(
+  expectTransformation(
     `
     jest.spyOn().mockReturnValue();
     spyOn(stuff).and.callThrough();
@@ -37,7 +37,7 @@ test('spyOn', () => {
 })
 
 test('jasmine.createSpy', () => {
-  assertTransformation(
+  expectTransformation(
     `
     jasmine.createSpy();
     jasmine.createSpy('lmao');
@@ -68,7 +68,7 @@ test('not supported jasmine.createSpy().and.*', () => {
 })
 
 test('*.calls.count()', () => {
-  assertTransformation(
+  expectTransformation(
     `
     someMock.calls.count();
     stuff.someMock.calls.count();
@@ -99,7 +99,7 @@ test('*.calls.count()', () => {
 })
 
 test('*.mostRecentCall', () => {
-  assertTransformation(
+  expectTransformation(
     `
     wyoming.cheyenne.stuff.mostRecentCall.args[0]
     georgia.atlanta.mostRecentCall.args.map(fn)
@@ -112,7 +112,7 @@ test('*.mostRecentCall', () => {
 })
 
 test('*.calls.mostRecent()', () => {
-  assertTransformation(
+  expectTransformation(
     `
     const foo = someMock.calls.mostRecent();
     someMock.calls.mostRecent()[0];
@@ -129,7 +129,7 @@ test('*.calls.mostRecent()', () => {
 })
 
 test('*.argsForCall', () => {
-  assertTransformation(
+  expectTransformation(
     `
     oklahoma.argsForCall[0]
     idaho.argsForCall[0][1]
@@ -142,7 +142,7 @@ test('*.argsForCall', () => {
 })
 
 test('*.calls.argsFor()', () => {
-  assertTransformation(
+  expectTransformation(
     `
     oklahoma.calls.argsFor(0)
     idaho.calls.argsFor(0)[1]
@@ -155,7 +155,7 @@ test('*.calls.argsFor()', () => {
 })
 
 test('jasmine.clock()', () => {
-  assertTransformation(
+  expectTransformation(
     `
     jasmine.clock().install();
     jasmine.clock().uninstall();
@@ -182,7 +182,7 @@ test('not supported jasmine.clock()', () => {
 })
 
 test('jasmine.<jasmineToExpectFunctionName>(*)', () => {
-  assertTransformation(
+  expectTransformation(
     `
     jasmine.any(Function);
     jasmine.anything();
@@ -201,7 +201,7 @@ test('jasmine.<jasmineToExpectFunctionName>(*)', () => {
 })
 
 test('createSpyObj', () => {
-  assertTransformation(
+  expectTransformation(
     `
     const spyObj = jasmine.createSpyObj('label', ['a', 'b', 'hyphen-ated']);
     `,
@@ -216,7 +216,7 @@ test('createSpyObj', () => {
 })
 
 test('return value', () => {
-  assertTransformation(
+  expectTransformation(
     `
     focusMonitorMock = jasmine.createSpyObj('FocusMonitorMock', ['monitor', 'stopMonitoring']);
     focusMonitorMock.monitor.and.returnValue(of());
@@ -231,7 +231,7 @@ test('return value', () => {
   )
 })
 
-function assertTransformation(source, expectedOutput) {
+function expectTransformation(source, expectedOutput) {
   const result = wrappedPlugin(source)
   expect(result).toBe(expectedOutput)
 }

--- a/src/transformers/jasmine-this.test.ts
+++ b/src/transformers/jasmine-this.test.ts
@@ -7,16 +7,14 @@ import plugin from './jasmine-this'
 chalk.level = 0
 const wrappedPlugin = wrapPlugin(plugin)
 
-function testChanged(msg, source, expectedOutput, options = {}) {
-  test(msg, () => {
-    const result = wrappedPlugin(source, options)
-    expect(result).toBe(expectedOutput)
-  })
+function assertTransformation(source, expectedOutput, options = {}) {
+  const result = wrappedPlugin(source, options)
+  expect(result).toBe(expectedOutput)
 }
 
-testChanged(
-  'transforms simple cases',
-  `
+test('transforms simple cases', () => {
+  assertTransformation(
+    `
 describe('foo', function() {
     beforeEach(function() {
         this.foo = { id: 'FOO' };
@@ -30,7 +28,7 @@ describe('foo', function() {
     });
 });
 `,
-  `
+    `
 describe('foo', () => {
     let testContext;
 
@@ -50,11 +48,12 @@ describe('foo', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'does not transform generator functions',
-  `
+test('does not transform generator functions', () => {
+  assertTransformation(
+    `
 describe('foo', function*() {
     beforeEach(function*() {
         this.foo = { id: 'FOO' };
@@ -68,7 +67,7 @@ describe('foo', function*() {
     });
 });
 `,
-  `
+    `
 describe('foo', function*() {
     let testContext;
 
@@ -88,11 +87,12 @@ describe('foo', function*() {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'transforms only test functions context',
-  `
+test('transforms only test functions context', () => {
+  assertTransformation(
+    `
 describe('foo', function() {
     const MockClass = function(options) {
         this.options = options;
@@ -129,7 +129,7 @@ describe('bar', function () {
   });
 });
 `,
-  `
+    `
 describe('foo', () => {
     let testContext;
 
@@ -172,11 +172,12 @@ describe('bar', () => {
   });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'transforms nested describes',
-  `
+test('transforms nested describes', () => {
+  assertTransformation(
+    `
 describe('foo', function() {
     beforeEach(function() {
         this.foo = { id: 'FOO' };
@@ -198,7 +199,7 @@ describe('foo', function() {
     });
 });
 `,
-  `
+    `
 describe('foo', () => {
     let testContext;
 
@@ -226,11 +227,12 @@ describe('foo', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'transforms plain functions within lifecycle methods',
-  `
+test('transforms plain functions within lifecycle methods', () => {
+  assertTransformation(
+    `
 describe('foo', function() {
     beforeEach(function() {
         this.foo = { id: 'FOO' };
@@ -261,7 +263,7 @@ describe('foo', function() {
     });
 });
 `,
-  `
+    `
 describe('foo', () => {
     let testContext;
 
@@ -298,11 +300,12 @@ describe('foo', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'transforms context within arrow functions',
-  `
+test('transforms context within arrow functions', () => {
+  assertTransformation(
+    `
 describe('foo', () => {
     beforeEach(function() {
         this.foo = { id: 'FOO' };
@@ -313,7 +316,7 @@ describe('foo', () => {
     });
 });
 `,
-  `
+    `
 describe('foo', () => {
     let testContext;
 
@@ -330,11 +333,12 @@ describe('foo', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'transforms context within async functions',
-  `
+test('transforms context within async functions', () => {
+  assertTransformation(
+    `
 describe('foo', function () {
     beforeEach(async function() {
         this.foo = await globalPromise();
@@ -346,7 +350,7 @@ describe('foo', function () {
     });
 });
 `,
-  `
+    `
 describe('foo', () => {
     let testContext;
 
@@ -364,11 +368,12 @@ describe('foo', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'original issue example',
-  `
+test('original issue example', () => {
+  assertTransformation(
+    `
 beforeEach(function () {
     this.hello = 'hi';
 });
@@ -383,7 +388,7 @@ describe('context', () => {
     });
 });
 `,
-  `
+    `
 let testContext;
 
 beforeEach(() => {
@@ -404,11 +409,12 @@ describe('context', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'transforms before blocks',
-  `
+test('transforms before blocks', () => {
+  assertTransformation(
+    `
   beforeAll(function () {
     this.hello = 'hi';
   });
@@ -429,7 +435,7 @@ testChanged(
       });
   });
 `,
-  `
+    `
   let testContext;
 
   beforeAll(() => {
@@ -456,11 +462,12 @@ testChanged(
       });
   });
 `
-)
+  )
+})
 
-testChanged(
-  'does not transform mocha specific methods',
-  `
+test('does not transform mocha specific methods', () => {
+  assertTransformation(
+    `
 describe('foo', function () {
     it('should keep mocha methods', function() {
         this.timeout(500);
@@ -470,7 +477,7 @@ describe('foo', function () {
     });
 });
 `,
-  `
+    `
 describe('foo', () => {
     it('should keep mocha methods', () => {
         this.timeout(500);
@@ -480,11 +487,12 @@ describe('foo', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'ignores a function in an array',
-  `
+test('ignores a function in an array', () => {
+  assertTransformation(
+    `
 describe('foo', function() {
     it('should tolerate an array of functions', function() {
         foo.apply(model, [
@@ -495,7 +503,7 @@ describe('foo', function() {
     });
 });
 `,
-  `
+    `
 describe('foo', () => {
     it('should tolerate an array of functions', () => {
         foo.apply(model, [
@@ -506,11 +514,12 @@ describe('foo', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'adds any type to the test context with typescript (tsx)',
-  `
+test('adds any type to the test context with typescript (tsx)', () => {
+  assertTransformation(
+    `
   beforeEach(function () {
       this.hello = 'hi';
   });
@@ -525,7 +534,7 @@ testChanged(
       });
   });
   `,
-  `
+    `
   let testContext: any;
 
   beforeEach(() => {
@@ -546,12 +555,13 @@ testChanged(
       });
   });
   `,
-  { parser: 'tsx' }
-)
+    { parser: 'tsx' }
+  )
+})
 
-testChanged(
-  'adds any type to the test context with typescript (ts)',
-  `
+test('adds any type to the test context with typescript (ts)', () => {
+  assertTransformation(
+    `
 beforeEach(function () {
     this.hello = 'hi';
 });
@@ -566,7 +576,7 @@ describe('context', () => {
     });
 });
 `,
-  `
+    `
 let testContext: any;
 
 beforeEach(() => {
@@ -587,5 +597,6 @@ describe('context', () => {
     });
 });
 `,
-  { parser: 'ts' }
-)
+    { parser: 'ts' }
+  )
+})

--- a/src/transformers/jasmine-this.test.ts
+++ b/src/transformers/jasmine-this.test.ts
@@ -7,13 +7,13 @@ import plugin from './jasmine-this'
 chalk.level = 0
 const wrappedPlugin = wrapPlugin(plugin)
 
-function assertTransformation(source, expectedOutput, options = {}) {
+function expectTransformation(source, expectedOutput, options = {}) {
   const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
 }
 
 test('transforms simple cases', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function() {
     beforeEach(function() {
@@ -52,7 +52,7 @@ describe('foo', () => {
 })
 
 test('does not transform generator functions', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function*() {
     beforeEach(function*() {
@@ -91,7 +91,7 @@ describe('foo', function*() {
 })
 
 test('transforms only test functions context', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function() {
     const MockClass = function(options) {
@@ -176,7 +176,7 @@ describe('bar', () => {
 })
 
 test('transforms nested describes', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function() {
     beforeEach(function() {
@@ -231,7 +231,7 @@ describe('foo', () => {
 })
 
 test('transforms plain functions within lifecycle methods', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function() {
     beforeEach(function() {
@@ -304,7 +304,7 @@ describe('foo', () => {
 })
 
 test('transforms context within arrow functions', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', () => {
     beforeEach(function() {
@@ -337,7 +337,7 @@ describe('foo', () => {
 })
 
 test('transforms context within async functions', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function () {
     beforeEach(async function() {
@@ -372,7 +372,7 @@ describe('foo', () => {
 })
 
 test('original issue example', () => {
-  assertTransformation(
+  expectTransformation(
     `
 beforeEach(function () {
     this.hello = 'hi';
@@ -413,7 +413,7 @@ describe('context', () => {
 })
 
 test('transforms before blocks', () => {
-  assertTransformation(
+  expectTransformation(
     `
   beforeAll(function () {
     this.hello = 'hi';
@@ -466,7 +466,7 @@ test('transforms before blocks', () => {
 })
 
 test('does not transform mocha specific methods', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function () {
     it('should keep mocha methods', function() {
@@ -491,7 +491,7 @@ describe('foo', () => {
 })
 
 test('ignores a function in an array', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('foo', function() {
     it('should tolerate an array of functions', function() {
@@ -518,7 +518,7 @@ describe('foo', () => {
 })
 
 test('adds any type to the test context with typescript (tsx)', () => {
-  assertTransformation(
+  expectTransformation(
     `
   beforeEach(function () {
       this.hello = 'hi';
@@ -560,7 +560,7 @@ test('adds any type to the test context with typescript (tsx)', () => {
 })
 
 test('adds any type to the test context with typescript (ts)', () => {
-  assertTransformation(
+  expectTransformation(
     `
 beforeEach(function () {
     this.hello = 'hi';

--- a/src/transformers/mocha.test.ts
+++ b/src/transformers/mocha.test.ts
@@ -10,14 +10,14 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function assertTransformation(source, expectedOutput, options = {}) {
+function expectTransformation(source, expectedOutput, options = {}) {
   const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
 }
 
 test('maps BDD-style interface', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 describe('describe', () => {
@@ -62,7 +62,7 @@ describe('describe', () => {
 })
 
 test('maps TDD-style interface', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 suite('suite', () => {
@@ -103,7 +103,7 @@ describe('suite', () => {
 })
 
 test('preserves exclusive tests', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 suite.only('only suite', () => {
@@ -122,7 +122,7 @@ describe.only('only suite', () => {
 })
 
 test('preserves skipped tests', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 suite.skip('skip suite', () => {
@@ -145,7 +145,7 @@ describe.skip('skip suite', () => {
 })
 
 test('preserves call expressions that are defined in scope', () => {
-  assertTransformation(
+  expectTransformation(
     `
 const setup = () => {};
 context('test suite', () => {
@@ -172,7 +172,7 @@ describe('test suite', () => {
 })
 
 test('removes mocha import', () => {
-  assertTransformation(
+  expectTransformation(
     `
 import { describe, it } from 'mocha';
 suite('suite', () => {
@@ -186,7 +186,7 @@ describe('suite', () => {
 })
 
 test('adds any type to the test context with typescript (tsx)', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('describe', function () {
   beforeEach(function () {
@@ -230,7 +230,7 @@ describe('describe', () => {
 })
 
 test('adds any type to the test context with typescript (ts)', () => {
-  assertTransformation(
+  expectTransformation(
     `
 describe('describe', function () {
   beforeEach(function () {
@@ -274,7 +274,7 @@ describe('describe', () => {
 })
 
 test('transforms this', () => {
-  assertTransformation(
+  expectTransformation(
     `
 // @flow
 describe('describe', function () {

--- a/src/transformers/mocha.test.ts
+++ b/src/transformers/mocha.test.ts
@@ -10,17 +10,15 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(msg, source, expectedOutput, options = {}) {
-  test(msg, () => {
-    const result = wrappedPlugin(source, options)
-    expect(result).toBe(expectedOutput)
-    expect(consoleWarnings).toEqual([])
-  })
+function assertTransformation(source, expectedOutput, options = {}) {
+  const result = wrappedPlugin(source, options)
+  expect(result).toBe(expectedOutput)
+  expect(consoleWarnings).toEqual([])
 }
 
-testChanged(
-  'maps BDD-style interface',
-  `
+test('maps BDD-style interface', () => {
+  assertTransformation(
+    `
 // @flow
 describe('describe', () => {
   before(() => {});
@@ -40,7 +38,7 @@ describe('describe', () => {
   })
 })
 `,
-  `
+    `
 // @flow
 describe('describe', () => {
   beforeAll(() => {});
@@ -60,11 +58,12 @@ describe('describe', () => {
   })
 })
 `
-)
+  )
+})
 
-testChanged(
-  'maps TDD-style interface',
-  `
+test('maps TDD-style interface', () => {
+  assertTransformation(
+    `
 // @flow
 suite('suite', () => {
   suiteSetup(() => {});
@@ -82,7 +81,7 @@ suite('suite', () => {
   it('description', () => {});
 })
 `,
-  `
+    `
 // @flow
 describe('suite', () => {
   beforeAll(() => {});
@@ -100,29 +99,31 @@ describe('suite', () => {
   it('description', () => {});
 })
 `
-)
+  )
+})
 
-testChanged(
-  'preserves exclusive tests',
-  `
+test('preserves exclusive tests', () => {
+  assertTransformation(
+    `
 // @flow
 suite.only('only suite', () => {
   test.only('only test', () => {});
   it.only('only test', () => {});
 });
 `,
-  `
+    `
 // @flow
 describe.only('only suite', () => {
   test.only('only test', () => {});
   it.only('only test', () => {});
 });
 `
-)
+  )
+})
 
-testChanged(
-  'preserves skipped tests',
-  `
+test('preserves skipped tests', () => {
+  assertTransformation(
+    `
 // @flow
 suite.skip('skip suite', () => {
   test.skip('skip test', () => {});
@@ -131,7 +132,7 @@ suite.skip('skip suite', () => {
   it('test will be skipped');
 });
 `,
-  `
+    `
 // @flow
 describe.skip('skip suite', () => {
   test.skip('skip test', () => {});
@@ -140,11 +141,12 @@ describe.skip('skip suite', () => {
   it.skip('test will be skipped', () => {});
 });
 `
-)
+  )
+})
 
-testChanged(
-  'preserves call expressions that are defined in scope',
-  `
+test('preserves call expressions that are defined in scope', () => {
+  assertTransformation(
+    `
 const setup = () => {};
 context('test suite', () => {
     test('test', () => {
@@ -155,7 +157,7 @@ context('test suite', () => {
     });
 });
 `,
-  `
+    `
 const setup = () => {};
 describe('test suite', () => {
     test('test', () => {
@@ -166,24 +168,26 @@ describe('test suite', () => {
     });
 });
 `
-)
+  )
+})
 
-testChanged(
-  'removes mocha import',
-  `
+test('removes mocha import', () => {
+  assertTransformation(
+    `
 import { describe, it } from 'mocha';
 suite('suite', () => {
 })
     `,
-  `
+    `
 describe('suite', () => {
 })
     `
-)
+  )
+})
 
-testChanged(
-  'adds any type to the test context with typescript (tsx)',
-  `
+test('adds any type to the test context with typescript (tsx)', () => {
+  assertTransformation(
+    `
 describe('describe', function () {
   beforeEach(function () {
     this.hello = 'hi';
@@ -199,7 +203,7 @@ describe('describe', function () {
   })
 })
 `,
-  `
+    `
 describe('describe', () => {
   let testContext: any;
 
@@ -221,12 +225,13 @@ describe('describe', () => {
   })
 })
 `,
-  { parser: 'tsx' }
-)
+    { parser: 'tsx' }
+  )
+})
 
-testChanged(
-  'adds any type to the test context with typescript (ts)',
-  `
+test('adds any type to the test context with typescript (ts)', () => {
+  assertTransformation(
+    `
 describe('describe', function () {
   beforeEach(function () {
     this.hello = 'hi';
@@ -242,7 +247,7 @@ describe('describe', function () {
   })
 })
 `,
-  `
+    `
 describe('describe', () => {
   let testContext: any;
 
@@ -264,12 +269,13 @@ describe('describe', () => {
   })
 })
 `,
-  { parser: 'ts' }
-)
+    { parser: 'ts' }
+  )
+})
 
-testChanged(
-  'transforms this',
-  `
+test('transforms this', () => {
+  assertTransformation(
+    `
 // @flow
 describe('describe', function () {
   before(function() {
@@ -306,7 +312,7 @@ describe('describe', function () {
   })
 })
 `,
-  `
+    `
 // @flow
 describe('describe', () => {
   let testContext;
@@ -349,4 +355,5 @@ describe('describe', () => {
   })
 })
 `
-)
+  )
+})

--- a/src/transformers/should.test.ts
+++ b/src/transformers/should.test.ts
@@ -13,17 +13,15 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(msg, source, expectedOutput) {
-  test(msg, () => {
-    const result = wrappedPlugin(source)
-    expect(result).toBe(expectedOutput)
-    expect(consoleWarnings).toEqual([])
-  })
+function assertTransformation(source, expectedOutput) {
+  const result = wrappedPlugin(source)
+  expect(result).toBe(expectedOutput)
+  expect(consoleWarnings).toEqual([])
 }
 
-testChanged(
-  'removes imports and does basic conversions of should.js',
-  `
+test('removes imports and does basic conversions of should.js', () => {
+  assertTransformation(
+    `
         var should = require('should');
 
         var user = {
@@ -37,7 +35,7 @@ testChanged(
         should.throws(foo, /^Description/);
         should(foo).be.undefined();
     `,
-  `
+    `
         var user = {
             name: 'tj'
           , pets: ['tobi', 'loki', 'jane', 'bandit']
@@ -49,15 +47,17 @@ testChanged(
         expect(foo).toThrowError(/^Description/);
         expect(foo).toBeUndefined();
     `
-)
+  )
+})
 
-testChanged(
-  'leaves code without should/expect',
-  `
+test('leaves code without should/expect', () => {
+  assertTransformation(
+    `
         function test() {
             i.have.a.dream();
             i.have.a.dream;
         }
         `,
-  null
-)
+    null
+  )
+})

--- a/src/transformers/should.test.ts
+++ b/src/transformers/should.test.ts
@@ -13,14 +13,14 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function assertTransformation(source, expectedOutput) {
+function expectTransformation(source, expectedOutput) {
   const result = wrappedPlugin(source)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
 }
 
 test('removes imports and does basic conversions of should.js', () => {
-  assertTransformation(
+  expectTransformation(
     `
         var should = require('should');
 
@@ -51,7 +51,7 @@ test('removes imports and does basic conversions of should.js', () => {
 })
 
 test('leaves code without should/expect', () => {
-  assertTransformation(
+  expectTransformation(
     `
         function test() {
             i.have.a.dream();

--- a/src/transformers/tape.test.ts
+++ b/src/transformers/tape.test.ts
@@ -14,14 +14,14 @@ beforeEach(() => {
   console.warn = (v) => consoleWarnings.push(v)
 })
 
-function testChanged(source, expectedOutput, options = {}) {
+function expectTransformation(source, expectedOutput, options = {}) {
   const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
   expect(consoleWarnings).toEqual([])
 }
 
 test('does not touch code without tape require/import', () => {
-  testChanged(
+  expectTransformation(
     `
 const test = require("testlib");
 test(t => {
@@ -36,7 +36,7 @@ test(t => {
 })
 
 test('changes code without tape require/import if skipImportDetection is set', () => {
-  testChanged(
+  expectTransformation(
     `
 test(t => {
     t.notOk(1);
@@ -50,7 +50,7 @@ test(t => {
 })
 
 test('CommonJs requires', () => {
-  testChanged(
+  expectTransformation(
     `
 const test = require('tape');
 const x = 1;
@@ -62,7 +62,7 @@ const x = 1;
 })
 
 test('ES2015 imports', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 const x = 1;
@@ -74,7 +74,7 @@ const x = 1;
 })
 
 test('maps assertions and comments', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test((t) => {
@@ -189,7 +189,7 @@ test(done => {
 })
 
 test('rewriting non standard naming of test function and t argument', () => {
-  testChanged(
+  expectTransformation(
     `
 import myTapeTest from "tape";
 myTapeTest("mytest", t => {
@@ -229,7 +229,7 @@ test(function() {
 })
 
 test('test options: removes', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test('mytest', {objectPrintDepth: 4, skip: false}, t => {
@@ -245,7 +245,7 @@ test('mytest', () => {
 })
 
 test('test options: skip', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test('mytest', {objectPrintDepth: 4, skip: true}, t => {
@@ -261,7 +261,7 @@ test.skip('mytest', () => {
 })
 
 test('removes t.end in scope of test function', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test('mytest', t => {
@@ -278,7 +278,7 @@ test('mytest', () => {
 })
 
 test('keeps t.end in nested functions', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 
@@ -299,7 +299,7 @@ test(done => {
 })
 
 test('removes t.pass but keeps t.fail', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape'
 
@@ -329,7 +329,7 @@ test('handles done.fail and done.pass', done => {
 })
 
 test('t.throws', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test(t => {
@@ -351,7 +351,7 @@ test(() => {
 })
 
 test('destructured test argument', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test(({ok}) => {
@@ -373,7 +373,7 @@ test('my test', () => {
 })
 
 test(`supports the todo option`, () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test({todo: true}, t => {
@@ -508,7 +508,7 @@ test('graciously warns about unknown destructured assertions', () => {
 })
 
 test('supports renaming non standard import name', () => {
-  testChanged(
+  expectTransformation(
     `
 import foo from 'tape';
 foo(() => {});
@@ -520,7 +520,7 @@ test(() => {});
 })
 
 test('doesNotThrow works with `expected` argument', () => {
-  testChanged(
+  expectTransformation(
     `
 import test from 'tape';
 test('foo', t => {


### PR DESCRIPTION
This PR refactored all transformation tests to have real test cases instead of implicit dynamically generate one. The benefits are
- that it is more clear what a test case is and what not, especially to first time contributors
- that IDEs can successfully find and execute individual test cases.

This has been discussed with @skovhus while fixing #200. 