### PR TITLE
Less strict matching for spyOn().and.*(..)

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -19,7 +19,9 @@ test('spyOn', () => {
     jest.spyOn().mockReturnValue();
     spyOn(stuff).and.callThrough();
     spyOn(stuff).and.callFake(() => 'lol');
+    existingSpy.and.callFake(() => 'lol');
     spyOn(stuff).and.returnValue('lmao');
+    existingSpy.and.returnValue('lmao');
     jest.spyOn();
     spyOn(stuff);
     jest.spyOn().mockImplementation();
@@ -28,7 +30,9 @@ test('spyOn', () => {
     jest.spyOn().mockReturnValue();
     jest.spyOn(stuff);
     jest.spyOn(stuff).mockImplementation(() => 'lol');
+    existingSpy.mockImplementation(() => 'lol');
     jest.spyOn(stuff).mockReturnValue('lmao');
+    existingSpy.mockReturnValue('lmao');
     jest.spyOn();
     jest.spyOn(stuff).mockImplementation(() => {});
     jest.spyOn().mockImplementation();

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -131,28 +131,25 @@ export default function jasmineGlobals(fileInfo, api, options) {
 
   root
     .find(j.CallExpression, {
-      // find spyOn().and.*() expressions
-      callee: {
+       // find *.and.*() expressions, e.g.
+       // - `spyOn().and.callThrough()`,
+       // - `spyOn().and.callFake(..)`
+       // - `existingSpy.and.callFake(..)`
+       // - `spyOn().and.returnValue(..)`
+       // - `existingSpy.and.returnValue(..)`
+       callee: {
         type: 'MemberExpression',
         object: {
           type: 'MemberExpression',
           property: { name: 'and' },
-          object: {
-            type: 'CallExpression',
-            callee: {
-              type: 'Identifier',
-              name: 'spyOn',
-            },
-          },
         },
       },
     })
     .forEach((path) => {
       const spyType = path.node.callee.property.name
       switch (spyType) {
-        // if it's `spyOn().and.callThrough()`
-        // we should remove it and make just `spyOn()`
-        // because jest calls through by default
+        // if it's `*.and.callThrough()` we should remove
+        // `and.callThrough()` because jest calls through by default
         case 'callThrough': {
           const { callee } = path.node.callee.object.object
           const arg = path.node.callee.object.object.arguments
@@ -160,15 +157,15 @@ export default function jasmineGlobals(fileInfo, api, options) {
           path.node.arguments = arg
           break
         }
-        // if it's `spyOn().and.callFake()` replace with jest's
-        // equivalent `spyOn().mockImplementation();
+        // if it's `*.and.callFake()`, replace with jest's
+        // equivalent `*.mockImplementation();
         case 'callFake': {
           path.node.callee.object = path.node.callee.object.object
           path.node.callee.property.name = 'mockImplementation'
           break
         }
-        // `spyOn().and.returnValue()` is equivalent of
-        // `jest.spyOn().mockReturnValue()`
+        // `*.and.returnValue()` is equivalent of jest
+        // `*.mockReturnValue()`
         case 'returnValue': {
           path.node.callee.object = path.node.callee.object.object
           path.node.callee.property.name = 'mockReturnValue'


### PR DESCRIPTION
Specifically, when matching for `.and.returnValue()`, `.and.callThrough()`,
and `.and.callFake()`, we now accept any preceding object, not only the
common use case of `spyOn().and.*`.

This allows for correct transformation of tests which separate the declaration
of the spy object from the declaration of its behaviour, e.g. by declaring
the spy in `beforeEach()` and configuring it within a test case.

Ref: https://github.com/skovhus/jest-codemods/issues/207