### PR TITLE
fix: spawn `jscodeshift` cli using node

### DIFF
--- a/src/cli/transformers.ts
+++ b/src/cli/transformers.ts
@@ -2,7 +2,7 @@ import execa from 'execa'
 import path from 'path'
 
 export const transformerDirectory = path.join(__dirname, '../', 'transformers')
-export const jscodeshiftExecutable = require.resolve('.bin/jscodeshift')
+export const jscodeshiftExecutable = require.resolve('jscodeshift/bin/jscodeshift.js')
 
 type Flags = {
   dry?: boolean
@@ -50,7 +50,7 @@ function executeTransformation({
 
   console.log(`Executing command: jscodeshift ${args.join(' ')}`)
 
-  const result = execa.sync(jscodeshiftExecutable, args, {
+  const result = execa.sync('node', [jscodeshiftExecutable, ...args], {
     stdio: 'inherit',
     stripFinalNewline: false,
   })


### PR DESCRIPTION
**What's the problem this PR addresses?**

`jest-codemods` tries to spawn sh files on Windows by spawning `node_modules/.bin/jscodeshift`

**How did you fix it?**

Resolve the JS CLI directly and spawn it using node