### PR TITLE
Allow names other than t for ava execution context

### DIFF
--- a/src/transformers/ava.test.ts
+++ b/src/transformers/ava.test.ts
@@ -328,6 +328,71 @@ test('my test', () => {
   )
 })
 
+test('supports other test names', () => {
+  expectTransformation(
+    `
+import test from 'ava';
+
+test('my test', async (test) => {
+  test.is('msg', 'other msg');
+  const deeper = () => {
+    test.is('deeper', 'even deeper');
+  };
+  const willNotChange = (test) => {
+    test.is('notChanged', 'notChanged');
+  };
+  const alsoNoChange = () => {
+    const test = {};
+    test.is('notChanged', 'notChanged');
+  }
+});
+
+test('another test', async (x) => {
+  x.is('msg', 'other msg');
+  const deeper = () => {
+    x.is('deeper', 'even deeper');
+  };
+  const willNotChange = (x) => {
+    x.is('notChanged', 'notChanged');
+  };
+  const alsoNoChange = () => {
+    const x = {};
+    x.is('notChanged', 'notChanged');
+  }
+});
+`,
+    `
+test('my test', async () => {
+  expect('msg').toBe('other msg');
+  const deeper = () => {
+    expect('deeper').toBe('even deeper');
+  };
+  const willNotChange = (test) => {
+    test.is('notChanged', 'notChanged');
+  };
+  const alsoNoChange = () => {
+    const test = {};
+    test.is('notChanged', 'notChanged');
+  }
+});
+
+test('another test', async () => {
+  expect('msg').toBe('other msg');
+  const deeper = () => {
+    expect('deeper').toBe('even deeper');
+  };
+  const willNotChange = (x) => {
+    x.is('notChanged', 'notChanged');
+  };
+  const alsoNoChange = () => {
+    const x = {};
+    x.is('notChanged', 'notChanged');
+  }
+});
+`
+  )
+})
+
 test('converts test.todo', () => {
   expectTransformation(
     `
@@ -378,18 +443,6 @@ test('not supported warnings: unmapped t property', () => {
     `)
   expect(consoleWarnings).toEqual([
     'jest-codemods warning: (test.js line 4) "t.unknownAssert" is currently not supported',
-  ])
-})
-
-test('not supported warnings: non standard argument for test', () => {
-  wrappedPlugin(`
-        import test from 'ava';
-        test(x => {
-            x.equal(1, 1);
-        });
-    `)
-  expect(consoleWarnings).toEqual([
-    'jest-codemods warning: (test.js line 3) Argument to test function should be named "t" not "x"',
   ])
 })
 

--- a/src/transformers/ava.test.ts
+++ b/src/transformers/ava.test.ts
@@ -491,3 +491,43 @@ test(() => {});
 `
   )
 })
+
+test('can handle after.always or afterEach.always', () => {
+  expectTransformation(
+    `
+import test from 'ava';
+
+test.after.always(t => {});
+test.afterEach.always(t => {});
+`,
+    `
+afterAll(() => {});
+afterEach(() => {});
+`
+  )
+})
+
+test('does not mess with the context', () => {
+  expectTransformation(
+    `
+import test from 'ava';
+
+test.beforeEach((test) => {
+  test.context.hello = () => console.log('hello');
+});
+
+test('uses context', test => {
+  test.context.hello();
+});
+`,
+    `
+beforeEach(() => {
+  test.context.hello = () => console.log('hello');
+});
+
+test('uses context', () => {
+  context.hello();
+});
+`
+  )
+})

--- a/src/transformers/jasmine-this.ts
+++ b/src/transformers/jasmine-this.ts
@@ -1,9 +1,9 @@
 /**
  * Codemod for transforming Jasmine `this` context into Jest v20+ compatible syntax.
  */
+import { NodePath } from 'ast-types'
 import * as jscodeshift from 'jscodeshift'
 import { Collection } from 'jscodeshift/src/Collection'
-import { NodePath } from 'recast'
 
 import finale from '../utils/finale'
 

--- a/src/utils/tape-ava-helpers.ts
+++ b/src/utils/tape-ava-helpers.ts
@@ -11,6 +11,9 @@ const { namedTypes } = types
  */
 function renameTestFunctionArgument(j, path, newArgument) {
   const lastArg = path.node.arguments[path.node.arguments.length - 1]
+  if (!lastArg) {
+    return
+  }
   if (lastArg.type === 'ArrowFunctionExpression') {
     const arrowFunction = j.arrowFunctionExpression(
       [j.identifier(newArgument === '' ? '()' : newArgument)],
@@ -251,4 +254,3 @@ export function detectUnsupportedNaming(fileInfo, j, ast, testFunctionName) {
       }
     })
 }
-

--- a/src/utils/tape-ava-helpers.ts
+++ b/src/utils/tape-ava-helpers.ts
@@ -1,8 +1,5 @@
-import { types } from 'recast'
-
 import logger from './logger'
 
-const { namedTypes } = types
 /**
  * Rewrite last argument of a given CallExpression path
  * @param  {jscodeshift} j
@@ -209,14 +206,6 @@ export function renameExecutionInterface(fileInfo, j, ast, testFunctionName) {
                     return
                   }
                   scope = scope.parent
-                }
-                const parent = path.parent.node
-                if (
-                  namedTypes.Property.check(parent) &&
-                  parent.shorthand &&
-                  !parent.method
-                ) {
-                  path.parent.get('shorthand').replace(false)
                 }
 
                 path.node.callee.object.name = 't'


### PR DESCRIPTION
Updates to:

  * ava parser

In my company we often use the following, and I would much rather update this lib than fix all the tests by hand.
```typescript
import test from 'ava';

test('some test', (test) => {
  ...
});
```