### PR TITLE
Add sinon + enzyme chai matchers

### DIFF
--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -19,16 +19,6 @@ function expectTransformation(source, expectedOutput) {
   expect(consoleWarnings).toEqual([])
 }
 
-// test.only('TEST DEBUG', () => {
-//   const arr = ['a', 'b', 'c']
-//   // expect(arr).toContain('a')
-//   // expect(arr).toEqual(expect.arrayContaining(['a']))
-//   // const a = 'a'
-//   const a = ['a']
-//   expect(arr).toEqual(expect.arrayContaining(a))
-//   // expect(arr).toContain(a)
-// })
-
 test('chai-enzyme: handle .to.contain(JSXElement)', () => {
   expectTransformation(
     `

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -9,6 +9,10 @@ export const PROP_WITH_SECONDS_ARGS = [
 
 export const JEST_MATCHER_TO_MAX_ARGS = {
   toBe: 1,
+  toBeCalled: 0,
+  toBeCalledTimes: 1,
+  toBeCalledWith: Infinity,
+  toBeLastCalledWith: Infinity,
   toBeCloseTo: 2,
   toBeDefined: 0,
   toBeFalsy: 0,


### PR DESCRIPTION
Adds additional chai matchers to support common sinon + enzyme cases:
- chai-enzyme:
    - `.to.be.present()`
    - `.to.contain.keys()`
    - `.to.have.type()`
    - `.to.have.state()`
    - `.to.have.descendants()`
- chai-sinon:
    - `.to.be.called` + `calledOnce`, `calledTwice`, etc
    - `.to.have.called()`
    - `.to.have.been.calledWithMatch()`
    - `.to.be.calledWithExactly()`
- `.to.have.prop()` + `.to.have.prop()s`

Also includes:
- handles `.not.to` -> `.to.not` cases
- refines `equals` cases


cc @lencioni @danbeam