### PR TITLE
Make sinon.stub() mock implementation when nothing is returned (& other tweaks)

### DIFF
--- a/src/transformers/sinon.test.ts
+++ b/src/transformers/sinon.test.ts
@@ -11,10 +11,13 @@ beforeEach(() => {
   jest.spyOn(console, 'warn').mockImplementation().mockClear()
 })
 
-function expectTransformation(source, expectedOutput, options = {}) {
-  const result = wrappedPlugin(source, options)
+function expectTransformation(source, expectedOutput, warnings = []) {
+  const result = wrappedPlugin(source)
   expect(result).toBe(expectedOutput)
-  expect(console.warn).toBeCalledTimes(0)
+  expect(console.warn).toBeCalledTimes(warnings.length)
+  warnings.forEach((warning, i) => {
+    expect(console.warn).nthCalledWith(i + 1, warning)
+  })
 }
 
 it('removes imports', () => {
@@ -34,21 +37,37 @@ describe('spies and stubs', () => {
     expectTransformation(
       `
         import sinon from 'sinon-sandbox'
-        const stub = sinon.stub(Api, 'get')
+
+        const stub = sinon.stub(Api, 'get');
+        const putOk = sinon.stub(Api, 'put').returns(200)
+        sinon.stub(I18n); // unsupported
         sinon.stub(I18n, 'extend');
-        sinon.stub(AirbnbUser, 'current').returns(currentUser);
+        sinon.stub(AirbnbUser, 'current').returnsArg(1);
+        sinon.stub(a, b, () => c, d) // too many args
+
         sinon.spy(I18n, 'extend');
         sinon.spy();
         sinon.spy(() => 'foo');
+        sinon.spy(a, b, () => c, d) // too many args
 `,
       `
-        const stub = jest.spyOn(Api, 'get').mockClear()
-        jest.spyOn(I18n, 'extend').mockClear();
-        jest.spyOn(AirbnbUser, 'current').mockClear().mockReturnValue(currentUser);
+        const stub = jest.spyOn(Api, 'get').mockClear().mockImplementation();
+        const putOk = jest.spyOn(Api, 'put').mockClear().mockReturnValue(200)
+        sinon.stub(I18n); // unsupported
+        jest.spyOn(I18n, 'extend').mockClear().mockImplementation();
+        jest.spyOn(AirbnbUser, 'current').mockClear().mockImplementation((...args) => args[1]);
+        jest.spyOn(a, b).mockClear().mockImplementation(() => c) // too many args
+
         jest.spyOn(I18n, 'extend').mockClear();
         jest.fn();
-        jest.fn().mockImplementation(() => 'foo');
-`
+        jest.fn(() => 'foo');
+        jest.spyOn(a, b).mockClear().mockImplementation(() => c) // too many args
+`,
+      [
+        'jest-codemods warning: (test.js line 6) stubbing all methods in an object is not supported; stub each one you care about individually',
+        'jest-codemods warning: (test.js line 9) 4+ arguments found in sinon.stub call; did you mean to use this many?',
+        'jest-codemods warning: (test.js line 14) 4+ arguments found in sinon.spy call; did you mean to use this many?',
+      ]
     )
   })
 
@@ -79,8 +98,8 @@ describe('spies and stubs', () => {
 `,
       `
         beforeEach(() => {
-          jest.spyOn(Api, 'get').mockClear()
-          const s1 = jest.spyOn(I18n, 'extend').mockClear()
+          jest.spyOn(Api, 'get').mockClear().mockImplementation()
+          const s1 = jest.spyOn(I18n, 'extend').mockClear().mockImplementation()
           const s2 = jest.spyOn(I18n, 'extend').mockClear().mockReturnValue('en')
           jest.spyOn(L10n, 'language').mockClear().mockReturnValue('en')
           jest.spyOn(I18n, 'extend').mockClear().mockImplementation(() => 'foo');


### PR DESCRIPTION
cc @lencioni @catc

In some recent PRs I noticed that `sinon.stub(a, b)` is transformed into `jest.spyOn(a, b).mockClear()` but it also needs a `.mockImplementation()` in the general case (when there's not a `.return()` or `.returnArg()`).  So I've added that.

Additionally, I read sinon's doc on `stub()` and `spy()` and we don't need/implement `stub(a)` (which mocks all keys in the object) so I'm marking that as unsupported (it's not advised even from sinon's doc).

I added a warning when there's more than 3 arguments (which doesn't seem to be valid, AFAICT).

I also changed `jest.fn().mockImplementation(...)` to just `jest.fn(...)` because it's equivalent and shorter.