### PR TITLE
More chai/sinon patches (take 2)

### DIFF
--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -120,8 +120,8 @@ test('removes imports and does basic conversions of should and expect', () => {
     `
         describe('Instantiating TextField', () => {
             it('should set the placeholder correctly', () => {
-                expect(textField.props.placeholder).toEqual(PLACEHOLDER);
-                expect(textField.props.placeholder).not.toEqual(PLACEHOLDER);
+                expect(textField.props.placeholder).toBe(PLACEHOLDER);
+                expect(textField.props.placeholder).not.toBe(PLACEHOLDER);
             });
         });
     `
@@ -156,13 +156,13 @@ test('removes imports and does basic conversions of should and expect (2)', () =
     `
         describe('Instantiating TextField', () => {
             it('should set the placeholder correctly', () => {
-                expect(textField.props.placeholder).toEqual(PLACEHOLDER);
-                expect(textField.props.placeholder).not.toEqual(PLACEHOLDER);
+                expect(textField.props.placeholder).toBe(PLACEHOLDER);
+                expect(textField.props.placeholder).not.toBe(PLACEHOLDER);
             });
 
             it('should inherit id prop', () => {
-                expect(dropdown.props.id).toEqual(STANDARD_PROPS.id);
-                expect(dropdown.props.id).not.toEqual(STANDARD_PROPS.id);
+                expect(dropdown.props.id).toBe(STANDARD_PROPS.id);
+                expect(dropdown.props.id).not.toBe(STANDARD_PROPS.id);
             });
 
             it('should map open prop to visible prop', () => {
@@ -190,8 +190,8 @@ test('removes imports (case where should is not assigned)', () => {
     `
         describe('Instantiating TextField', () => {
           it('should set the placeholder correctly', () => {
-              expect(textField.props.placeholder).toEqual(PLACEHOLDER);
-              expect(textField.props.placeholder).not.toEqual(PLACEHOLDER);
+              expect(textField.props.placeholder).toBe(PLACEHOLDER);
+              expect(textField.props.placeholder).not.toBe(PLACEHOLDER);
           });
         });`
   )
@@ -456,22 +456,28 @@ test('converts "equal"', () => {
         expect(42).to.equal(42);
         expect(1).to.not.equal(true);
         expect({ foo: 'bar' }).to.not.equal({ foo: 'bar' });
+
         expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
+        expect({ foo: 'bar' }).not.to.deep.equal({ foo: 'bar' });
+        expect({ foo: 'bar' }).to.not.deep.equal({ foo: 'bar' });
 
         should.equal('foo', 'foo');
         should.not.equal('foo', 'bar');
     `,
     `
-        expect('hello').toEqual('hello');
+        expect('hello').toBe('hello');
         // some message here explaining hello
-        expect('hello').toEqual('hello');
-        expect(42).toEqual(42);
-        expect(1).not.toEqual(true);
-        expect({ foo: 'bar' }).not.toEqual({ foo: 'bar' });
-        expect({ foo: 'bar' }).toEqual({ foo: 'bar' });
+        expect('hello').toBe('hello');
+        expect(42).toBe(42);
+        expect(1).not.toBe(true);
+        expect({ foo: 'bar' }).not.toBe({ foo: 'bar' });
 
-        expect('foo').toEqual('foo');
-        expect('foo').not.toEqual('bar');
+        expect({ foo: 'bar' }).toEqual({ foo: 'bar' });
+        expect({ foo: 'bar' }).not.toEqual({ foo: 'bar' });
+        expect({ foo: 'bar' }).not.toEqual({ foo: 'bar' });
+
+        expect('foo').toBe('foo');
+        expect('foo').not.toBe('bar');
     `
   )
 })
@@ -1030,11 +1036,11 @@ test('removes params to expect() except for the first', () => {
         // Expected foo to be defined
         expect(foo).toBeDefined();
         // Expected foo to be defined
-        expect(foo).toEqual(true);
+        expect(foo).toBe(true);
         // Expected foo to be defined for \${id}
         expect(foo).toBeDefined();
         // 'Expected ' + foo + ' to be defined'
-        expect(foo).toEqual(true);
+        expect(foo).toBe(true);
     `
   )
 })
@@ -1117,6 +1123,47 @@ test('converts equalto(null) to toBeNull()', () => {
     `
   )
 })
+
+test('converts subtly different equality operators', () => {
+  expectTransformation(
+    `
+        // Strict equality (===)
+        expect(2 + 2).to.eq(5);
+        expect(2 + 2).to.equal(5);
+        expect(2 + 2).to.equals(5);
+        expect(2 + 2).to.not.equals(5);
+        expect(2 + 2).not.to.equals(5);
+
+        // Strict equality (===) + deep = deep equality
+        expect(2 + 2).to.deep.eq(5);
+
+        // Deep equality
+        expect(2 + 2).to.eql(5);
+        expect(2 + 2).to.eqls(5);
+        expect(2 + 2).to.not.eqls(5);
+        expect(2 + 2).not.to.eqls(5);
+        expect(2 + 2).to.deep.eql(5);
+    `,
+    `
+        // Strict equality (===)
+        expect(2 + 2).toBe(5);
+        expect(2 + 2).toBe(5);
+        expect(2 + 2).toBe(5);
+        expect(2 + 2).not.toBe(5);
+        expect(2 + 2).not.toBe(5);
+
+        // Strict equality (===) + deep = deep equality
+        expect(2 + 2).toEqual(5);
+
+        // Deep equality
+        expect(2 + 2).toEqual(5);
+        expect(2 + 2).toEqual(5);
+        expect(2 + 2).not.toEqual(5);
+        expect(2 + 2).not.toEqual(5);
+        expect(2 + 2).toEqual(5);
+    `
+  )
+});
 
 test('converts "within"', () => {
   expectTransformation(

--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -25,7 +25,7 @@ test('chai-enzyme: handle .to.contain(JSXElement)', () => {
     expect(wrapper).to.contain(<ImpressionLogger />)
   `,
     `
-    expect(wrapper.contains(<ImpressionLogger />)).toEqual(true)
+    expect(wrapper).containsMatchingElement(<ImpressionLogger />)
   `
   )
 })
@@ -639,6 +639,17 @@ test('converts chained "includes-contains"', () => {
   )
 })
 
+test('chai-enzyme: handle .text() with .contains()', () => {
+  expectTransformation(
+    `
+      expect(wrapper.text()).to.contain(priceString);
+    `,
+    `
+      expect(wrapper.text()).toContain(priceString);
+    `
+  )
+})
+
 test('converts empty array assertion', () => {
   expectTransformation(
     `
@@ -1163,7 +1174,7 @@ test('converts subtly different equality operators', () => {
         expect(2 + 2).toEqual(5);
     `
   )
-});
+})
 
 test('converts "within"', () => {
   expectTransformation(
@@ -1266,9 +1277,10 @@ it('leaves code without should/expect', () => {
   expect(result).toBeNull()
 })
 
-it('converts before, after and context to beforeAll, afterAll and describe', () => {
-  expectTransformation(
-    `
+describe('converts before, after and context to beforeAll, afterAll and describe', () => {
+  it('converts cases correctly', () => {
+    expectTransformation(
+      `
         before(() => {
           doSetup();
         });
@@ -1285,7 +1297,7 @@ it('converts before, after and context to beforeAll, afterAll and describe', () 
           });
         });
     `,
-    `
+      `
         beforeAll(() => {
           doSetup();
         });
@@ -1302,7 +1314,25 @@ it('converts before, after and context to beforeAll, afterAll and describe', () 
           });
         });
     `
-  )
+    )
+  })
+
+  it('skips call expression spreads with the same identifier', () => {
+    expectTransformation(
+      `
+      const foo = {
+        a: 'aa',
+        ...context(searchParams),
+      }
+    `,
+      `
+      const foo = {
+        a: 'aa',
+        ...context(searchParams),
+      }
+    `
+    )
+  })
 })
 
 test('supports chai-arrays plugin', () => {

--- a/src/transformers/chai-should.ts
+++ b/src/transformers/chai-should.ts
@@ -684,6 +684,15 @@ export default function transformer(fileInfo, api, options) {
               return createCall('toMatchObject', args, rest, containsNot)
             }
 
+            // handle `expect(wrapper.text()).to.contain('string')`
+            const expectArg = rest.arguments[0]
+            if (
+              expectArg?.type === j.CallExpression.name &&
+              expectArg.callee?.property?.name === 'text'
+            ) {
+              return createCall('toContain', args, rest, containsNot)
+            }
+
             const expectNode = getExpectNode(value)
             if (expectNode != null) {
               // handle `expect([1, 2]).toContain(1)
@@ -703,16 +712,7 @@ export default function transformer(fileInfo, api, options) {
 
             // handle `expect(wrapper).to.contain(<div />)`
             if (args?.[0]?.type === j.JSXElement.name) {
-              return createCall(
-                'toEqual',
-                [j.identifier('true')],
-                updateExpect(value, (node) => {
-                  return j.callExpression(
-                    j.memberExpression(node, j.identifier('contains')),
-                    [args[0]]
-                  )
-                })
-              )
+              return createCall('containsMatchingElement', args, rest, containsNot)
             }
 
             return createCall(
@@ -931,6 +931,13 @@ export default function transformer(fileInfo, api, options) {
       })
       .replaceWith((p) => {
         const { value } = p
+        /* 
+          if call expression is spread, don't transform, eg:
+          const foo = { params: ...context(searchParams) }
+        */
+        if (p.parentPath?.value?.type === j.SpreadElement.name) {
+          return value
+        }
         return j.callExpression(
           j.identifier(chaiToJestGlobalMethods[value.callee.name]),
           value.arguments

--- a/src/transformers/chai-should.ts
+++ b/src/transformers/chai-should.ts
@@ -635,7 +635,7 @@ export default function transformer(fileInfo, api, options) {
           case 'eql':
           case 'eq':
           case 'equal':
-          case 'equals':
+          case 'equals': {
             if (numberOfArgs === 1) {
               const { type } = firstArg
 
@@ -652,7 +652,16 @@ export default function transformer(fileInfo, api, options) {
               }
             }
 
-            return createCall('toEqual', args, rest, containsNot)
+            const containsDeep = chainContains('deep', value.callee, isPrefix)
+            const isStrict = ['equal', 'equals', 'eq'].includes(propertyName)
+
+            return createCall(
+              isStrict && !containsDeep ? 'toBe' : 'toEqual',
+              args,
+              rest,
+              containsNot
+            )
+          }
           case 'throw':
             return createCall('toThrowError', args, rest, containsNot)
           case 'string':

--- a/src/transformers/sinon.ts
+++ b/src/transformers/sinon.ts
@@ -204,7 +204,7 @@ function transformCalledWithAssertions(j, ast) {
 /* 
 sinon.stub(Api, 'get') -> jest.spyOn(Api, 'get')
 */
-function transformStub(j: core.JSCodeshift, ast, sinonExpression, logWarning) {
+function transformStub(j, ast, sinonExpression, logWarning) {
   ast
     .find(j.CallExpression, {
       callee: {
@@ -256,8 +256,8 @@ function transformStub(j: core.JSCodeshift, ast, sinonExpression, logWarning) {
           }
         } else if (propertyName === 'stub') {
           const parent =
-            findParentOfType(np, 'VariableDeclaration') ||
-            findParentOfType(np, 'ExpressionStatement')
+            findParentOfType(np, j.VariableDeclaration.name) ||
+            findParentOfType(np, j.ExpressionStatement.name)
 
           const hasReturn =
             j(parent)

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -27,6 +27,7 @@ export const JEST_MATCHER_TO_MAX_ARGS = {
   toBeUndefined: 0,
   toContain: 1,
   toContainEqual: 1,
+  containsMatchingElement: 1,
   toEqual: 1,
   toHaveBeenCalled: 0,
   toHaveBeenCalledTimes: 1,


### PR DESCRIPTION
@skovhus this is https://github.com/skovhus/jest-codemods/pull/315 without amending the old commit.

I wrote https://github.com/danbeam/jest-codemods/commit/171f96d46a9d1225abafbb3aa87995aeb9a16d46 chronologically before https://github.com/skovhus/jest-codemods/pull/291 but forgot to upstream it (whoops) so I'm doing that now.

@catc wrote https://github.com/danbeam/jest-codemods/commit/d2b3d76e3e14772b83bbc07dcd796ea5193f2c53 and I wrote https://github.com/danbeam/jest-codemods/commit/ddc2c66b16d4493573839f55d79223ecd3e6f1d6.  cc @lencioni