### PR TITLE
Add some optional behaviors to sinon transformer

### DIFF
--- a/src/transformers/sinon.ts
+++ b/src/transformers/sinon.ts
@@ -748,7 +748,8 @@ export default function transformer(fileInfo: FileInfo, api: API, options) {
 
   let fixJSDomPragma
 
-  if (options.keepJestEnvironment) fixJSDomPragma = handleJSDomPragma(j, ast, fileInfo.path)
+  if (options.keepJestEnvironment)
+    fixJSDomPragma = handleJSDomPragma(j, ast, fileInfo.path)
 
   const sinonExpression =
     removeDefaultImport(j, ast, 'sinon-sandbox') || removeDefaultImport(j, ast, 'sinon')


### PR DESCRIPTION
Hey again @skovhus 👋 !

I've been modifying the sinon transform for code I'm migrating, but I'm not sure these options are useful for everybody.  I've currently forked your repo but am working to undo that (and just depend on jest-codemods), so I've included some code that might be useful to only some users behind flags.

If somebody wants to use them:

```sh
jscodeshift --keepJestEnvironment --legacyLastCall -t path/to/src/transformers/sinon.ts <file-to-transform>
```

Pass flags to codemods is documented here https://github.com/facebook/jscodeshift#options.

Note: most of this was originally written by @catc (cc also @lencioni).