### PR TITLE
[sinon] Implement `stub.resetBehavior()` and `stub.resetHistory()`

### DIFF
--- a/src/transformers/sinon.test.ts
+++ b/src/transformers/sinon.test.ts
@@ -379,12 +379,16 @@ describe('mocks', () => {
         Api.get.restore()
         Api.get.reset()
         sinon.restore()
+        stub.resetBehavior()
+        stub.resetHistory()
 `,
       `
         stub.mockRestore()
         Api.get.mockRestore()
         Api.get.mockReset()
         jest.restoreAllMocks()
+        stub.mockReset()
+        stub.mockReset()
 `
     )
   })

--- a/src/transformers/sinon.ts
+++ b/src/transformers/sinon.ts
@@ -35,6 +35,8 @@ const SINON_CALLED_WITH_METHODS = ['calledWith', 'notCalledWith']
 const SINON_SPY_METHODS = ['spy', 'stub']
 const SINON_MOCK_RESETS = {
   reset: 'mockReset',
+  resetBehavior: 'mockReset',
+  resetHistory: 'mockReset',
   restore: 'mockRestore',
 }
 const SINON_MATCHERS = {


### PR DESCRIPTION
ref: https://sinonjs.org/releases/latest/stubs/

>stub.reset();
Resets both behaviour and history of the stub.
This is equivalent to calling both stub.resetBehavior() and stub.resetHistory()