### PR TITLE
Sinon: add support for transforming callsFake

### DIFF
--- a/src/transformers/sinon.test.ts
+++ b/src/transformers/sinon.test.ts
@@ -56,8 +56,11 @@ describe('spies and stubs', () => {
 
         const stub = sinon.stub(Api, 'get');
         const putOk = sinon.stub(Api, 'put').returns(200)
+        sinon.stub();
+        sinon.stub().returns(Promise.resolve());
         sinon.stub(I18n); // unsupported
         sinon.stub(I18n, 'extend');
+        sinon.stub(I18n, 'extend').callsFake(fn => fn);
         sinon.stub(AirbnbUser, 'current').returnsArg(1);
         sinon.stub(a, b, () => c, d) // too many args
 
@@ -69,8 +72,11 @@ describe('spies and stubs', () => {
       `
         const stub = jest.spyOn(Api, 'get').mockClear().mockImplementation();
         const putOk = jest.spyOn(Api, 'put').mockClear().mockReturnValue(200)
+        jest.fn();
+        jest.fn().mockReturnValue(Promise.resolve());
         sinon.stub(I18n); // unsupported
         jest.spyOn(I18n, 'extend').mockClear().mockImplementation();
+        jest.spyOn(I18n, 'extend').mockClear().mockImplementation(fn => fn);
         jest.spyOn(AirbnbUser, 'current').mockClear().mockImplementation((...args) => args[1]);
         jest.spyOn(a, b).mockClear().mockImplementation(() => c) // too many args
 
@@ -81,9 +87,9 @@ describe('spies and stubs', () => {
 `,
       {
         warnings: [
-          'jest-codemods warning: (test.js line 6) stubbing all methods in an object is not supported; stub each one you care about individually',
-          'jest-codemods warning: (test.js line 9) 4+ arguments found in sinon.stub call; did you mean to use this many?',
-          'jest-codemods warning: (test.js line 14) 4+ arguments found in sinon.spy call; did you mean to use this many?',
+          'jest-codemods warning: (test.js line 8) stubbing all methods in an object is not supported; stub each one you care about individually',
+          'jest-codemods warning: (test.js line 12) 4+ arguments found in sinon.stub call; did you mean to use this many?',
+          'jest-codemods warning: (test.js line 17) 4+ arguments found in sinon.spy call; did you mean to use this many?',
         ],
       }
     )

--- a/src/transformers/sinon.ts
+++ b/src/transformers/sinon.ts
@@ -344,6 +344,21 @@ function transformStub(j, ast, sinonExpression, logWarning) {
             findParentOfType(np, j.VariableDeclaration.name) ||
             findParentOfType(np, j.ExpressionStatement.name)
 
+          const callsFake = j(parent).find(j.CallExpression, {
+            callee: {
+              type: 'MemberExpression',
+              property: { type: 'Identifier', name: 'callsFake' },
+            },
+          })
+          const hasCallsFake = callsFake.size() > 0
+
+          if (hasCallsFake) {
+            callsFake.forEach((np) => {
+              np.node.callee.property.name = 'mockImplementation'
+            })
+            return spyOn
+          }
+
           const hasReturn =
             j(parent)
               .find(j.CallExpression, {


### PR DESCRIPTION
Hello!

When running the codemods on a quite large test suite, I noticed that `sinon.stub(obj, 'prop').callsFake(fn)` does not seem to be transformed. Docs: https://sinonjs.org/releases/latest/stubs/#properties

I changed it so, that 
```js
sinon.stub(I18n, 'extend').callsFake(fn => fn);
``` 
will be turned into 
```js
jest.spyOn(I18n, 'extend').mockClear().mockImplementation(fn => fn);
``` 
which should be the expected result.

I also added a couple of additional test cases to verify that `sinon.stub()` without arguments is transformed correctly (no changes in the code were needed). 

ping @skovhus 