### PR TITLE
chai-should: improve contain transformations

### DIFF
--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -611,16 +611,24 @@ test('converts "includes-contains"', () => {
   expectTransformation(
     `
         expect('foobar').to.contain('foo');
+        expect(fn('foobar')).to.contain('foo');
+        expect(fn('foobar')).to.contain(\`foo\`);
         expect([1, 2, 3]).to.include(2);
         expect('foobar').which.contains('foo');
         expect({ foo: 1, bar: 2 }).to.contain({ bar: 2 });
+        expect(a).to.contain('foo');
+        expect(a).to.contain(fn('bar'));
         expect(a).to.contain(b);
     `,
     `
         expect('foobar').toContain('foo');
+        expect(fn('foobar')).toContain('foo');
+        expect(fn('foobar')).toContain(\`foo\`);
         expect([1, 2, 3]).toContain(2);
         expect('foobar').toContain('foo');
         expect({ foo: 1, bar: 2 }).toMatchObject({ bar: 2 });
+        expect(a).toContain('foo');
+        expect(a).toContain(fn('bar'));
         expect(a).toEqual(expect.arrayContaining([b]));
     `
   )

--- a/src/transformers/chai-should.ts
+++ b/src/transformers/chai-should.ts
@@ -686,10 +686,13 @@ export default function transformer(fileInfo, api, options) {
 
             // handle `expect(wrapper.text()).to.contain('string')`
             const expectArg = rest.arguments[0]
-            if (
-              expectArg?.type === j.CallExpression.name &&
-              expectArg.callee?.property?.name === 'text'
-            ) {
+            const isExpectArgCallExpression = expectArg.type === j.CallExpression.name
+
+            // handle `expect(a).to.contain(fn('bar'))`
+            const containsArg = args?.[0]
+            const isContainsArgCallExpression = containsArg.type === j.CallExpression.name
+
+            if (isExpectArgCallExpression || isContainsArgCallExpression) {
               return createCall('toContain', args, rest, containsNot)
             }
 


### PR DESCRIPTION
Hello,

When transforming a large test suite I noticed that the `.to.contain` transformations are not done very well when there are function calls involved. 

In the case when the argument for `expect()` or `.to.contain()` is a function call, it would be better to simply transform `.to.contain()` => `.toContain()` to avoid any problematic results, which is what my changes do.

Since in Jest's `.toContain` works on strings and arrays, it should not be needed to transform `.to.contain` to anything more complicated when we don't know what the result of the function call is.

A real example from the codebase that I'm transforming:

```js
expect(getLink("en")).to.contain(encodeURIComponent("test client name en"));
```
...gets transformed to:

```js
expect(getLink("en")).toEqual(expect.arrayContaining([encodeURIComponent("test client name en")]));
```

...and after these changes:

```js
expect(getLink("en")).toContain(encodeURIComponent("test client name en"));
```

ping @skovhus 

