### PR TITLE
chai-should: don't use Jest's alias names

### DIFF
--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -166,8 +166,8 @@ test('removes imports and does basic conversions of should and expect (2)', () =
             });
 
             it('should map open prop to visible prop', () => {
-                expect(dropdown.props.visible).toThrowError(STANDARD_PROPS.open);
-                expect(dropdown.props.id).not.toThrowError(STANDARD_PROPS.id);
+                expect(dropdown.props.visible).toThrow(STANDARD_PROPS.open);
+                expect(dropdown.props.id).not.toThrow(STANDARD_PROPS.id);
             });
 
             thing1.equal(thing2);
@@ -307,10 +307,10 @@ test('converts "called"', () => {
         expect(sinonSpy).to.be.not.called;
     `,
     `
-        expect(sinonSpy).toBeCalled();
-        expect(sinonSpy).not.toBeCalled();
-        expect(sinonSpy).not.toBeCalled();
-        expect(sinonSpy).not.toBeCalled();
+        expect(sinonSpy).toHaveBeenCalled();
+        expect(sinonSpy).not.toHaveBeenCalled();
+        expect(sinonSpy).not.toHaveBeenCalled();
+        expect(sinonSpy).not.toHaveBeenCalled();
     `
   )
 })
@@ -324,10 +324,10 @@ test('converts "called.exactly(n)"', () => {
         expect(sinonSpy).to.not.have.been.called.exactly(3)
     `,
     `
-        expect(sinonSpy).toBeCalledTimes(3)
-        expect(sinonSpy).not.toBeCalledTimes(3)
-        expect(sinonSpy).toBeCalledTimes(3)
-        expect(sinonSpy).not.toBeCalledTimes(3)
+        expect(sinonSpy).toHaveBeenCalledTimes(3)
+        expect(sinonSpy).not.toHaveBeenCalledTimes(3)
+        expect(sinonSpy).toHaveBeenCalledTimes(3)
+        expect(sinonSpy).not.toHaveBeenCalledTimes(3)
     `
   )
 })
@@ -339,8 +339,8 @@ test('converts "callCount"', () => {
         expect(sinonSpy).not.to.have.callCount(2);
     `,
     `
-        expect(sinonSpy).toBeCalledTimes(1);
-        expect(sinonSpy).not.toBeCalledTimes(2);
+        expect(sinonSpy).toHaveBeenCalledTimes(1);
+        expect(sinonSpy).not.toHaveBeenCalledTimes(2);
     `
   )
 })
@@ -352,8 +352,8 @@ test('converts "calledOnce"', () => {
         expect(sinonSpy).not.to.be.calledOnce;
     `,
     `
-        expect(sinonSpy).toBeCalledTimes(1);
-        expect(sinonSpy).not.toBeCalledTimes(1);
+        expect(sinonSpy).toHaveBeenCalledTimes(1);
+        expect(sinonSpy).not.toHaveBeenCalledTimes(1);
     `
   )
 })
@@ -365,8 +365,8 @@ test('converts "calledTwice"', () => {
         expect(sinonSpy).not.to.be.calledTwice;
     `,
     `
-        expect(sinonSpy).toBeCalledTimes(2);
-        expect(sinonSpy).not.toBeCalledTimes(2);
+        expect(sinonSpy).toHaveBeenCalledTimes(2);
+        expect(sinonSpy).not.toHaveBeenCalledTimes(2);
     `
   )
 })
@@ -378,8 +378,8 @@ test('converts "calledThrice"', () => {
         expect(sinonSpy).not.to.be.calledThrice;
     `,
     `
-        expect(sinonSpy).toBeCalledTimes(3);
-        expect(sinonSpy).not.toBeCalledTimes(3);
+        expect(sinonSpy).toHaveBeenCalledTimes(3);
+        expect(sinonSpy).not.toHaveBeenCalledTimes(3);
     `
   )
 })
@@ -391,8 +391,8 @@ test('converts "calledWith"', () => {
         expect(sinonSpy).not.to.be.calledWith('a', 'b');
     `,
     `
-        expect(sinonSpy).toBeCalledWith(1, 2, 3);
-        expect(sinonSpy).not.toBeCalledWith('a', 'b');
+        expect(sinonSpy).toHaveBeenCalledWith(1, 2, 3);
+        expect(sinonSpy).not.toHaveBeenCalledWith('a', 'b');
     `
   )
 })
@@ -406,7 +406,7 @@ it('converts "calledWithMatch"', () => {
         });
     `,
     `
-        expect(stub).toBeCalledWith(expect.objectContaining({
+        expect(stub).toHaveBeenCalledWith(expect.objectContaining({
           foo: 'foo',
           bar: 1
         }));
@@ -421,8 +421,8 @@ test('converts "calledWithExactly"', () => {
         expect(sinonSpy).not.to.be.calledWithExactly('a', 'b');
     `,
     `
-        expect(sinonSpy).toBeCalledWith(1, 2, 3);
-        expect(sinonSpy).not.toBeCalledWith('a', 'b');
+        expect(sinonSpy).toHaveBeenCalledWith(1, 2, 3);
+        expect(sinonSpy).not.toHaveBeenCalledWith('a', 'b');
     `
   )
 })
@@ -955,12 +955,12 @@ test('converts "throw"', () => {
     `
         const err = new ReferenceError('This is a bad function.');
         const fn = function() { throw err; };
-        expect(fn).toThrowError(ReferenceError);
-        expect(fn).toThrowError(Error);
-        expect(fn).toThrowError(/bad function/);
-        expect(fn).not.toThrowError('good function');
-        expect(fn).toThrowError(ReferenceError);
-        expect(fn).toThrowError(err);
+        expect(fn).toThrow(ReferenceError);
+        expect(fn).toThrow(Error);
+        expect(fn).toThrow(/bad function/);
+        expect(fn).not.toThrow('good function');
+        expect(fn).toThrow(ReferenceError);
+        expect(fn).toThrow(err);
     `
   )
 })

--- a/src/transformers/chai-should.ts
+++ b/src/transformers/chai-should.ts
@@ -513,13 +513,13 @@ export default function transformer(fileInfo, api, options) {
           case 'function':
             return typeOf(p, value, [j.literal('function')], containsNot)
           case 'called':
-            return createCall('toBeCalled', [], rest, containsNot)
+            return createCall('toHaveBeenCalled', [], rest, containsNot)
           case 'calledonce':
-            return createCall('toBeCalledTimes', [j.literal(1)], rest, containsNot)
+            return createCall('toHaveBeenCalledTimes', [j.literal(1)], rest, containsNot)
           case 'calledtwice':
-            return createCall('toBeCalledTimes', [j.literal(2)], rest, containsNot)
+            return createCall('toHaveBeenCalledTimes', [j.literal(2)], rest, containsNot)
           case 'calledthrice':
-            return createCall('toBeCalledTimes', [j.literal(3)], rest, containsNot)
+            return createCall('toHaveBeenCalledTimes', [j.literal(3)], rest, containsNot)
           default:
             return value
         }
@@ -617,17 +617,22 @@ export default function transformer(fileInfo, api, options) {
             )
           }
           case 'callcount':
-            return createCall('toBeCalledTimes', args, rest, containsNot)
+            return createCall('toHaveBeenCalledTimes', args, rest, containsNot)
           case 'calledwith':
-            return createCall('toBeCalledWith', args, rest, containsNot)
+            return createCall('toHaveBeenCalledWith', args, rest, containsNot)
           case 'calledwithmatch':
-            return createCall('toBeCalledWith', args.map(containing), rest, containsNot)
+            return createCall(
+              'toHaveBeenCalledWith',
+              args.map(containing),
+              rest,
+              containsNot
+            )
           case 'calledwithexactly':
-            return createCall('toBeCalledWith', args, rest, containsNot)
+            return createCall('toHaveBeenCalledWith', args, rest, containsNot)
           case 'exactly':
             // handle `expect(sinonSpy).to.have.called.exactly(3)`
             if (chainContains('called', value.callee, isPrefix)) {
-              return createCall('toBeCalledTimes', [firstArg], rest, containsNot)
+              return createCall('toHaveBeenCalledTimes', [firstArg], rest, containsNot)
             }
             return value
           case 'equalto':
@@ -663,7 +668,7 @@ export default function transformer(fileInfo, api, options) {
             )
           }
           case 'throw':
-            return createCall('toThrowError', args, rest, containsNot)
+            return createCall('toThrow', args, rest, containsNot)
           case 'string':
             return createCall('toContain', args, rest, containsNot)
           case 'state':

--- a/src/transformers/should.test.ts
+++ b/src/transformers/should.test.ts
@@ -44,7 +44,7 @@ test('removes imports and does basic conversions of should.js', () => {
         expect(user).toHaveProperty('name', 'tj');
         expect(user).toHaveProperty('name', 'tj');
         expect(true).toBeTruthy();
-        expect(foo).toThrowError(/^Description/);
+        expect(foo).toThrow(/^Description/);
         expect(foo).toBeUndefined();
     `
   )


### PR DESCRIPTION
Hello,

When transforming a large codebase, I noticed that when chai syntax is transformed to Jest, the matchers are using alias names instead of the default names.

There is a `eslint-plugin-jest` rule that can migrate the method names, but it would be good to do that by default.
https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-alias-methods.md

The alias names are possibly also getting removed from Jest (https://github.com/facebook/jest/issues/13164), so this would be a good way to future proof the code.

ping @skovhus 