### PR TITLE
chai-should: don't update member expressions inside expect calls

### DIFF
--- a/src/transformers/chai-should.test.ts
+++ b/src/transformers/chai-should.test.ts
@@ -302,15 +302,30 @@ test('converts "called"', () => {
   expectTransformation(
     `
         expect(sinonSpy).to.be.called;
+        expect(sinonSpy).to.be.called();
         expect(sinonSpy).not.to.be.called;
         expect(sinonSpy).to.not.be.called;
         expect(sinonSpy).to.be.not.called;
     `,
     `
         expect(sinonSpy).toHaveBeenCalled();
+        expect(sinonSpy).toHaveBeenCalled();
         expect(sinonSpy).not.toHaveBeenCalled();
         expect(sinonSpy).not.toHaveBeenCalled();
         expect(sinonSpy).not.toHaveBeenCalled();
+    `
+  )
+})
+
+test('does not convert "fetchMock.called()"', () => {
+  expectTransformation(
+    `
+        expect(fetchMock.called("/url")).to.equal(true);
+        expect(fetchMock.called()).to.equal(true);
+    `,
+    `
+        expect(fetchMock.called("/url")).toBe(true);
+        expect(fetchMock.called()).toBe(true);
     `
   )
 })

--- a/src/transformers/chai-should.ts
+++ b/src/transformers/chai-should.ts
@@ -197,6 +197,10 @@ export default function transformer(fileInfo, api, options) {
 
   const isExpectCall = (node) => isExpectCallUtil(j, node)
 
+  const isInsideExpectCall = (path) =>
+    findParentOfType(path.parentPath.parentPath, 'CallExpression')?.value.callee.name ===
+    'expect'
+
   const typeOf = (path, value, args, containsNot) => {
     switch (args[0].value) {
       case 'null':
@@ -398,6 +402,7 @@ export default function transformer(fileInfo, api, options) {
           },
         })
         .filter((p) => findParentOfType(p, 'ExpressionStatement'))
+        .filter((p) => !isInsideExpectCall(p))
         .filter((p) => {
           const { value } = p
           const propertyName = value.property.name.toLowerCase()


### PR DESCRIPTION
Hello again,

I noticed that the `chai-should` codemod did fail to properly transform `expect(fetchMock.called("/url"))`. (docs: http://www.wheresrhys.co.uk/fetch-mock/)

I thought that a good fix would be not to update the matchers if they appear inside an `expect` call. This did not break any of the new or existing test cases.

I'm not sure if there is a better way than what I used in the `isInsideExpectCall` function that I added.

**input:**

```js
expect(fetchMock.called("/url")).to.equal(true);
```
**expected result:**
```js
expect(fetchMock.called("/url")).toBe(true);
```
**actual result before the fix:**
```js
expect(fetchMock.toHaveBeenCalled()).toBe(true);
```

ping @skovhus 