### PR TITLE
Codemod for auto-creating `@jest/globals` imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ $ jscodeshift -t node_modules/jest-codemods/dist/transformers/mocha.js test-fold
 $ jscodeshift -t node_modules/jest-codemods/dist/transformers/should.js test-folder
 $ jscodeshift -t node_modules/jest-codemods/dist/transformers/tape.js test-folder
 $ jscodeshift -t node_modules/jest-codemods/dist/transformers/sinon.js test-folder
+$ jscodeshift -t node_modules/jest-codemods/dist/transformers/jest-globals-import.js test-folder
 ```
 
 ## Test environment: Jest on Node.js or other

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "update-notifier": "5.1.0"
   },
   "devDependencies": {
+    "@jest/globals": "29.3.1",
     "@types/jest": "29.2.6",
     "@types/jscodeshift": "0.11.6",
     "@types/update-notifier": "5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ dependencies:
     version: 5.1.0
 
 devDependencies:
+  '@jest/globals':
+    specifier: 29.3.1
+    version: 29.3.1
   '@types/jest':
     specifier: 29.2.6
     version: 29.2.6

--- a/src/transformers/jest-globals-import.test.ts
+++ b/src/transformers/jest-globals-import.test.ts
@@ -74,7 +74,7 @@ const BLAH = 5;
   it('covers a less simple test', () => {
     expectTransformation(
       `
-import { expect, it } from '@jest/globals';
+import { expect as xpect, it } from '@jest/globals';
 import wrapWithStuff from 'test-utils/wrapWithStuff';
 
 describe('with foo=bar', () => {
@@ -84,12 +84,13 @@ describe('with foo=bar', () => {
   afterEach(() => jest.useRealTimers());
 
   it('works', () => {
-    expect(myThingIsEnabled(jest.fn())).toBe(true);
+    xpect(myThingIsEnabled(jest.fn())).toBe(true);
+    expect(1).toBe(1);
   });
 });
 `.trim(),
       `
-import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { expect as xpect, it, describe, beforeEach, afterEach, jest } from '@jest/globals';
 import wrapWithStuff from 'test-utils/wrapWithStuff';
 
 describe('with foo=bar', () => {
@@ -99,7 +100,8 @@ describe('with foo=bar', () => {
   afterEach(() => jest.useRealTimers());
 
   it('works', () => {
-    expect(myThingIsEnabled(jest.fn())).toBe(true);
+    xpect(myThingIsEnabled(jest.fn())).toBe(true);
+    expect(1).toBe(1);
   });
 });
 `.trim()

--- a/src/transformers/jest-globals-import.test.ts
+++ b/src/transformers/jest-globals-import.test.ts
@@ -1,0 +1,108 @@
+/* eslint-env jest */
+import { applyTransform } from 'jscodeshift/src/testUtils'
+
+import * as plugin from './jest-globals-import'
+
+function expectTransformation(source: string, expectedOutput: string | null) {
+  const result = applyTransform({ ...plugin, parser: 'ts' }, {}, { source })
+  expect(result).toBe(expectedOutput ?? '')
+}
+
+describe('jestGlobalsImport', () => {
+  it('covers a simple test', () => {
+    expectTransformation(
+      `
+it('works', () => {
+  expect(true).toBe(true);
+});
+`.trim(),
+      `
+import { expect, it } from '@jest/globals';
+it('works', () => {
+  expect(true).toBe(true);
+});
+`.trim()
+    )
+  })
+
+  it('ignores locally defined variables with the same name', () => {
+    expectTransformation(
+      `
+const test = () => { console.log('only a test'); };
+{
+  function b() {
+    function c() {
+      test();
+    }
+  }
+}
+`.trim(),
+      null
+    )
+  })
+
+  it('removes imports', () => {
+    expectTransformation(
+      `
+import '@jest/globals';
+const BLAH = 5;
+`.trim(),
+      `
+const BLAH = 5;
+`.trim()
+    )
+    expectTransformation(
+      `
+import { expect } from '@jest/globals';
+const BLAH = 5;
+`.trim(),
+      `
+const BLAH = 5;
+`.trim()
+    )
+    expectTransformation(
+      `
+import * as jestGlobals from '@jest/globals';
+const BLAH = 5;
+`.trim(),
+      `
+const BLAH = 5;
+`.trim()
+    )
+  })
+
+  it('covers a less simple test', () => {
+    expectTransformation(
+      `
+import { expect, it } from '@jest/globals';
+import wrapWithStuff from 'test-utils/wrapWithStuff';
+
+describe('with foo=bar', () => {
+  wrapWithStuff({ foo: 'bar' });
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('works', () => {
+    expect(myThingIsEnabled(jest.fn())).toBe(true);
+  });
+});
+`.trim(),
+      `
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import wrapWithStuff from 'test-utils/wrapWithStuff';
+
+describe('with foo=bar', () => {
+  wrapWithStuff({ foo: 'bar' });
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('works', () => {
+    expect(myThingIsEnabled(jest.fn())).toBe(true);
+  });
+});
+`.trim()
+    )
+  })
+})

--- a/src/transformers/jest-globals-import.ts
+++ b/src/transformers/jest-globals-import.ts
@@ -1,0 +1,146 @@
+import fs from 'fs'
+import type { Collection, ImportSpecifier, JSCodeshift } from 'jscodeshift'
+import path from 'path'
+
+// Inserts a new import statement at the top of the file.
+const addImport = ({
+  j,
+  ast,
+  src,
+  defaultImportName,
+  namedImports = new Set(),
+}: {
+  j: JSCodeshift
+  ast: Collection
+  src: string
+  defaultImportName?: string // e.g. the `React` in `import React from 'react';`.
+  namedImports?: Set<string> // e.g. the `{ name }` in `import { readFileSync } from 'fs';`.
+}) => {
+  const specifiers = []
+
+  if (defaultImportName) {
+    specifiers.push(j.importDefaultSpecifier(j.identifier(defaultImportName)))
+  }
+  Array.from(namedImports)
+    .sort()
+    .forEach((name) => {
+      specifiers.push(j.importSpecifier(j.identifier(name)))
+    })
+  const newImport = j.importDeclaration(specifiers, j.stringLiteral(src))
+
+  const program = ast.find(j.Program)
+  const hasTopComment = program.get('body', 0).node.comments?.length > 0
+  program.get('body', hasTopComment ? 1 : 0).insertBefore(newImport)
+}
+
+const ensureImportExists = ({
+  j,
+  ast,
+  src,
+  namedImports = new Set(),
+}: {
+  j: JSCodeshift
+  ast: Collection
+  src: string
+  namedImports?: Set<string>
+}) => {
+  const importDec = ast.find(j.ImportDeclaration, {
+    source: {
+      value: src,
+    },
+  })
+
+  if (importDec.length === 0) {
+    addImport({ j, ast, src, namedImports })
+    return
+  }
+
+  const { specifiers } = importDec.get().value
+
+  namedImports.forEach((name) => {
+    const importSpec = importDec.find(j.ImportSpecifier, { imported: { name } })
+    if (importSpec.length >= 1) return
+    specifiers.push(j.importSpecifier(j.identifier(name)))
+  })
+
+  specifiers.sort((spec1: ImportSpecifier, spec2: ImportSpecifier) =>
+    spec1.imported.name > spec2.imported.name ? 1 : -1
+  )
+}
+
+const jestGlobals = new Set<string>()
+
+const jestGlobalsPath = path.join(
+  __dirname,
+  '../../node_modules/@jest/globals/build/index.d.ts'
+)
+
+const ensureJestGlobalsPopulated = ({ j }: { j: JSCodeshift }) => {
+  if (jestGlobals.size > 0) return
+
+  const jestGlobalsAst = j(String(fs.readFileSync(jestGlobalsPath)), { parser: 'ts' })
+
+  jestGlobalsAst
+    .find(j.ExportNamedDeclaration, { declaration: { declare: true } })
+    .forEach((exportNamedDec) => {
+      if (exportNamedDec.node.declaration?.type !== 'VariableDeclaration') return
+      exportNamedDec.node.declaration.declarations.forEach((dec) => {
+        if (dec.type !== 'VariableDeclarator' || dec.id?.type !== 'Identifier') return
+        jestGlobals.add(dec.id.name)
+      })
+    })
+
+  jestGlobalsAst
+    .find(j.ExportSpecifier, { exported: { name: (n) => typeof n === 'string' } })
+    .forEach((exportSpecifier) => {
+      jestGlobals.add(exportSpecifier.node.exported.name)
+    })
+}
+
+const jestGlobalsImport = (
+  fileInfo: { path: string; source: string },
+  api: { jscodeshift: JSCodeshift }
+) => {
+  const { jscodeshift: j } = api
+  const ast = j(fileInfo.source)
+
+  ensureJestGlobalsPopulated({ j })
+
+  if (jestGlobals.size === 0) throw new Error("couldn't parse @jest/globals exports")
+
+  const jestGlobalsUsed = new Set<string>()
+
+  jestGlobals.forEach((globalName) => {
+    if (
+      ast
+        .find(j.CallExpression, { callee: { name: globalName } })
+        .filter((callExpression) => !callExpression.scope.lookup(globalName))
+        .size() > 0 ||
+      ast
+        .find(j.MemberExpression, { object: { name: globalName } })
+        .filter((memberExpression) => !memberExpression.scope.lookup(globalName))
+        .size() > 0
+    ) {
+      jestGlobalsUsed.add(globalName)
+    }
+  })
+
+  const existingJestGlobalsImport = ast.find(j.ImportDeclaration, {
+    importKind: 'value',
+    source: { value: '@jest/globals' },
+  })
+
+  const hasJestGlobalsImport = existingJestGlobalsImport.size() > 0
+  const needsJestGlobalsImport = jestGlobalsUsed.size > 0
+
+  if (!needsJestGlobalsImport) {
+    if (!hasJestGlobalsImport) return null
+    existingJestGlobalsImport.remove()
+  } else {
+    ensureImportExists({ j, ast, src: '@jest/globals', namedImports: jestGlobalsUsed })
+  }
+
+  return ast.toSource({ quote: 'single' })
+}
+
+export default jestGlobalsImport

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -44,3 +44,20 @@ export const JEST_MATCHER_TO_MAX_ARGS = {
 }
 
 export const JEST_MOCK_PROPERTIES = new Set(['spyOn', 'fn', 'createSpy'])
+
+export const JEST_GLOBALS = new Set<string>([
+  'afterAll',
+  'afterEach',
+  'beforeAll',
+  'beforeEach',
+  'describe',
+  'expect',
+  'fdescribe',
+  'fit',
+  'it',
+  'jest',
+  'test',
+  'xdescribe',
+  'xit',
+  'xtest',
+])


### PR DESCRIPTION
I recently had to convert a bit of code that used jest globals (e.g. `describe()`, `it()`, `expect()`) to explicitly importing these APIs from `@jest/globals`.

Before:
```ts
it('works', () => {
  expect(true).toBe(true);
});
```

After:
```ts
import { expect, it } from '@jest/globals';

it('works', () => {
  expect(true).toBe(true);
});
```

While doing that manually I thought: this would make a good codemod!

So I wrote a fairly simple one that actually scrapes the exports from the `@jest/globals` package itself[1], finds global usage, and adds imports.

[1] I don't use `require.resolve()` nor actually `import` it cuz both are enforcedly disallowed, which is a mild bummer, but overall I think it's still kinda slick.  If you know a better way, let me know!