### PR TITLE
feat: support `jest.setSystemTime`

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -164,24 +164,24 @@ test('jasmine.clock()', () => {
     jasmine.clock().install();
     jasmine.clock().uninstall();
     jasmine.clock().tick(50);
+    jasmine.clock().mockDate(new Date(2013, 9, 23));
     `,
     `
     jest.useFakeTimers();
     jest.useRealTimers();
     jest.advanceTimersByTime(50);
+    jest.setSystemTime(new Date(2013, 9, 23));
     `
   )
 })
 
 test('not supported jasmine.clock()', () => {
   wrappedPlugin(`
-        jasmine.clock().mockDate(new Date(2013, 9, 23));
         jasmine.clock().unknownUtil();
     `)
 
   expect(consoleWarnings).toEqual([
-    'jest-codemods warning: (test.js line 2) Unsupported Jasmine functionality "jasmine.clock().mockDate(*)".',
-    'jest-codemods warning: (test.js line 3) Unsupported Jasmine functionality "jasmine.clock().unknownUtil".',
+    'jest-codemods warning: (test.js line 2) Unsupported Jasmine functionality "jasmine.clock().unknownUtil".',
   ])
 })
 

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -431,9 +431,10 @@ export default function jasmineGlobals(fileInfo, api, options) {
           break
         }
         case 'mockDate': {
-          logWarning(
-            'Unsupported Jasmine functionality "jasmine.clock().mockDate(*)".',
-            path
+          // make it `jest.setSystemTime(date)`
+          path.node.callee = j.memberExpression(
+            j.identifier('jest'),
+            j.identifier('setSystemTime')
           )
           break
         }


### PR DESCRIPTION
Closes https://github.com/skovhus/jest-codemods/issues/570

Seems pretty straight forward. In the interest of keeping it simple, I opted to go with `setSystemTime` rather than trying to locate and pass a config option to `useFakeTimers`.