### PR TITLE
fix(`jasmine-globals`): fix transform for existing `spyOn`

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -28,6 +28,7 @@ test('spyOn', () => {
     jest.spyOn(stuff).and.resolveTo('lmao');
     jest.spyOn(stuff).and.rejectWith('oh no');
     const fetchSpy = spyOn(window, 'fetch').and.resolveTo({json: {}});
+    existingSpy.and.callThrough();
     `,
     `
     jest.spyOn().mockReturnValue();
@@ -42,6 +43,7 @@ test('spyOn', () => {
     jest.spyOn(stuff).mockResolvedValue('lmao');
     jest.spyOn(stuff).mockRejectedValue('oh no');
     const fetchSpy = jest.spyOn(window, 'fetch').mockResolvedValue({json: {}});
+    existingSpy;
     `
   )
 })

--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -43,7 +43,7 @@ test('spyOn', () => {
     jest.spyOn(stuff).mockResolvedValue('lmao');
     jest.spyOn(stuff).mockRejectedValue('oh no');
     const fetchSpy = jest.spyOn(window, 'fetch').mockResolvedValue({json: {}});
-    existingSpy;
+    existingSpy.mockRestore();
     `
   )
 })

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -161,10 +161,7 @@ export default function jasmineGlobals(fileInfo, api, options) {
         // if it's `*.and.callThrough()` we should remove
         // `and.callThrough()` because jest calls through by default
         case 'callThrough': {
-          const { callee } = path.node.callee.object.object
-          const arg = path.node.callee.object.object.arguments
-          path.node.callee = callee
-          path.node.arguments = arg
+          j(path).replaceWith(path.node.callee.object.object)
           break
         }
         // if it's `*.and.callFake()`, replace with jest's


### PR DESCRIPTION
Closes https://github.com/skovhus/jest-codemods/issues/579

Better handling of usage of `existingSpy.and.callThrough()`. This follows the same pattern as the legacy `andCallThrough` logic [here](https://github.com/puglyfe/jest-codemods/blob/fix-existing-spy-callthrough/src/transformers/jasmine-globals.ts#L392-L405).