### PR TITLE
fix(`jest-globals`): set array accessor type for parser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-codemods",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Codemods for migrating test files to Jest",
   "license": "MIT",
   "repository": "skovhus/jest-codemods",

--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -167,10 +167,12 @@ test.each(['babel', 'flow', 'ts'])('*.calls.argsFor() with parser `%s`', (parser
     `
     oklahoma.calls.argsFor(0)
     idaho.calls.argsFor(0)[1]
+    mySpy.calls.argsFor(myCounter)[0]
     `,
     `
     oklahoma.mock.calls[0]
     idaho.mock.calls[0][1]
+    mySpy.mock.calls[myCounter][0]
     `,
     {
       parser,

--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -162,7 +162,7 @@ test('*.argsForCall', () => {
   )
 })
 
-test('*.calls.argsFor()', () => {
+test.each(['babel', 'flow', 'ts'])('*.calls.argsFor() with parser `%s`', (parser) => {
   expectTransformation(
     `
     oklahoma.calls.argsFor(0)
@@ -171,7 +171,10 @@ test('*.calls.argsFor()', () => {
     `
     oklahoma.mock.calls[0]
     idaho.mock.calls[0][1]
-    `
+    `,
+    {
+      parser,
+    }
   )
 })
 
@@ -252,7 +255,7 @@ test('return value', () => {
   )
 })
 
-function expectTransformation(source, expectedOutput) {
-  const result = wrappedPlugin(source)
+function expectTransformation(source, expectedOutput, options = {}) {
+  const result = wrappedPlugin(source, options)
   expect(result).toBe(expectedOutput)
 }

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -372,9 +372,17 @@ export default function jasmineGlobals(fileInfo, api, options) {
       )
 
       // make it `*.mock.calls[index]`
-      j(path).replaceWith(
-        j.memberExpression(expressionMockCalls, j.literal(path.node.arguments[0].value))
-      )
+      if (path.node.arguments[0].type === 'Identifier') {
+        j(path).replaceWith(
+          // ex: `*.calls.argsFor(someVarReference)`
+          j.memberExpression(expressionMockCalls, path.node.arguments[0], true)
+        )
+      } else {
+        j(path).replaceWith(
+          // ex: `*.calls.argsFor(0)`
+          j.memberExpression(expressionMockCalls, j.literal(path.node.arguments[0].value))
+        )
+      }
     })
 
   root

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -372,7 +372,9 @@ export default function jasmineGlobals(fileInfo, api, options) {
       )
 
       // make it `*.mock.calls[index]`
-      j(path).replaceWith(j.memberExpression(expressionMockCalls, path.node.arguments[0]))
+      j(path).replaceWith(
+        j.memberExpression(expressionMockCalls, j.literal(path.node.arguments[0].value))
+      )
     })
 
   root

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -371,18 +371,16 @@ export default function jasmineGlobals(fileInfo, api, options) {
         j.identifier('calls')
       )
 
+      const expressionIndex =
+        path.node.arguments[0].type === 'Identifier'
+          ? j.memberExpression(expressionMockCalls, path.node.arguments[0], true)
+          : j.memberExpression(
+              expressionMockCalls,
+              j.literal(path.node.arguments[0].value)
+            )
+
       // make it `*.mock.calls[index]`
-      if (path.node.arguments[0].type === 'Identifier') {
-        j(path).replaceWith(
-          // ex: `*.calls.argsFor(someVarReference)`
-          j.memberExpression(expressionMockCalls, path.node.arguments[0], true)
-        )
-      } else {
-        j(path).replaceWith(
-          // ex: `*.calls.argsFor(0)`
-          j.memberExpression(expressionMockCalls, j.literal(path.node.arguments[0].value))
-        )
-      }
+      j(path).replaceWith(expressionIndex)
     })
 
   root


### PR DESCRIPTION
Fixes https://github.com/skovhus/jest-codemods/issues/585

Given an expression statement like `someSpy.calls.argsFor(0)[1]`, different parsers assign different `type` values to the `argsFor` arg node.

`babel` and `flow` parse it as `type: "Literal"`, where as `babylon`, `ts` and `tsx` parse it as `type: "NumericLiteral"`. When parsed as `NumericLiteral`, it results in invalid syntax when used as an array accessor.

This change updates the transform to explicitly set it as `type: "Literal"` regardless of the parser used. I also updated the test for this scenario to use multiple parsers. It's maybe a pattern that would be useful elsewhere, but I'll leave that as a separate effort 😅 

I also added support for `argsFor` args that are `type: "Identifier"` (e.g. `argsFor(someVariable)`).