### PR TITLE
TypeScript: Jasmine types like jasmine.SpyObj and jasmine.Spy should be migrated

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -94,6 +94,24 @@ test('jasmine.createSpy', () => {
   expect(consoleWarnings).toEqual([])
 })
 
+test('jasmine.createSpy with generic types', () => {
+  expectTransformation(
+    `
+    import type log from './log';
+    
+    jasmine.createSpy<typeof log>();
+    jasmine.createSpy<() => void>();
+    `,
+    `
+    import type log from './log';
+    
+    jest.fn<typeof log>();
+    jest.fn<() => void>();
+    `,
+    { parser: 'ts' }
+  )
+})
+
 test('not supported jasmine.createSpy().and.*', () => {
   wrappedPlugin(`
         jasmine.createSpy().and.unknownUtil();

--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -400,6 +400,24 @@ describe('createSpyObj', () => {
     `
     )
   })
+
+  test('with types', () => {
+    expectTransformation(
+      `
+    import { LoggerService } from './logger-service.ts';
+
+    const loggerSpy = jasmine.createSpyObj<LoggerService>('LoggerService', ['log']);
+    `,
+      `
+    import { LoggerService } from './logger-service.ts';
+
+    const loggerSpy: jest.Mocked<LoggerService> = {
+        'log': jest.fn()
+    };
+    `,
+      { parser: 'ts' }
+    )
+  })
 })
 
 describe('types', () => {

--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -384,6 +384,40 @@ describe('createSpyObj', () => {
   })
 })
 
+describe('types', () => {
+  test('jasmine.SpyObj', () =>
+    expectTransformation(
+      `
+      let loggerSpy: jasmine.SpyObj<LoggerService>;
+      let unknownSpy: jasmine.SpyObj<unknown>;
+      const errorHandlerSpy: jasmine.SpyObj<ErrorHandler> = jasmine.createSpyObj('ErrorHandler', ['handleError']);
+      `,
+      `
+      let loggerSpy: jest.Mocked<LoggerService>;
+      let unknownSpy: jest.Mocked<unknown>;
+      const errorHandlerSpy: jest.Mocked<ErrorHandler> = {
+            'handleError': jest.fn()
+      };
+      `,
+      { parser: 'ts' }
+    ))
+
+  test('jasmine.Spy', () =>
+    expectTransformation(
+      `
+        let setLanguageSpy: jasmine.Spy;
+        let logSpy: jasmine.Spy<(message: string) => void>;
+        const handleErrorSpy: jasmine.Spy<ErrorHandler['handleError']> = jasmine.createSpy();
+        `,
+      `
+        let setLanguageSpy: jest.Mock;
+        let logSpy: jest.Mock<(message: string) => void>;
+        const handleErrorSpy: jest.Mock<ErrorHandler['handleError']> = jest.fn();
+        `,
+      { parser: 'ts' }
+    ))
+})
+
 test('return value', () => {
   expectTransformation(
     `

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -713,10 +713,6 @@ export default function jasmineGlobals(fileInfo, api, options) {
       switch (typeName.right.name) {
         case 'Spy': {
           path.value.id.typeAnnotation = j.tsTypeAnnotation(
-            j.tsTypeReference(j.identifier('jest.Mock'))
-          )
-
-          path.value.id.typeAnnotation = j.tsTypeAnnotation(
             j.tsTypeReference(
               j.tsQualifiedName(j.identifier('jest'), j.identifier('Mock')),
               typeArgument ? j.tsTypeParameterInstantiation([typeArgument]) : null

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -113,7 +113,6 @@ export default function jasmineGlobals(fileInfo, api, options) {
       path.node.arguments = []
 
       const { typeParameters } = path.node
-      // Check if `createSpy` has type parameters and apply the same type parameters to `jest.fn()`
       if (typeParameters) {
         path.node.typeParameters = typeParameters
       }
@@ -638,6 +637,7 @@ export default function jasmineGlobals(fileInfo, api, options) {
       )
     })
     .forEach((path) => {
+      const { typeParameters } = path.node
       const [, spyObjMethods, spyObjProperties] = path.node.arguments
 
       const properties: ObjectProperty[] =
@@ -675,6 +675,15 @@ export default function jasmineGlobals(fileInfo, api, options) {
             : spyObjProperties.properties.map((arg) =>
                 j.objectProperty(j.literal(arg.key.name), arg.value)
               ))
+        )
+      }
+
+      if (typeParameters) {
+        path.parentPath.node.id.typeAnnotation = j.tsTypeAnnotation(
+          j.tsTypeReference(
+            j.tsQualifiedName(j.identifier('jest'), j.identifier('Mocked')),
+            typeParameters
+          )
         )
       }
 

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -111,6 +111,12 @@ export default function jasmineGlobals(fileInfo, api, options) {
       // make it `jest.fn()`
       path.node.callee = j.memberExpression(j.identifier('jest'), j.identifier('fn'))
       path.node.arguments = []
+
+      const { typeParameters } = path.node
+      // Check if `createSpy` has type parameters and apply the same type parameters to `jest.fn()`
+      if (typeParameters) {
+        path.node.typeParameters = typeParameters
+      }
     })
 
   root // find all global `spyOn` calls that are standalone expressions.

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -111,11 +111,6 @@ export default function jasmineGlobals(fileInfo, api, options) {
       // make it `jest.fn()`
       path.node.callee = j.memberExpression(j.identifier('jest'), j.identifier('fn'))
       path.node.arguments = []
-
-      const { typeParameters } = path.node
-      if (typeParameters) {
-        path.node.typeParameters = typeParameters
-      }
     })
 
   root // find all global `spyOn` calls that are standalone expressions.


### PR DESCRIPTION
fixes #609 