### PR TITLE
feat(jasmine): add matcher transforms that have no direct equivalent in jest, but can be expressed in other ways

### DIFF
--- a/src/transformers/expect.test.ts
+++ b/src/transformers/expect.test.ts
@@ -96,8 +96,13 @@ test('maps expect matchers', () => {
       expect(stuff).toBeAn(Array);
       expect(new Stuff).toBeAn(Stuff, 'Message');
 
+      expect([1, 2]).toHaveSize(2);
+
       expect(stuff).toNotBeA(Number);
       expect(stuff).toNotBeAn(Array);
+
+      expect(foo).toBePositiveInfinity();
+      expect(foo).toBeNegativeInfinity();
 
       expect(stuff).toMatch({foo: 'bar'});
       expect(stuff).toMatch({foo: 'bar'}, 'message');
@@ -113,6 +118,10 @@ test('maps expect matchers', () => {
       expect(stuff).toNotHaveBeenCalled();
       expect(stuff).toNotHaveBeenCalled('msg');
       expect(stuff).toHaveBeenCalledWith('foo', 'bar');
+
+      expect(mySpy).toHaveBeenCalledOnceWith('foo', 'bar');
+      expect(mySpy).toHaveBeenCalledBefore(myOtherSpy);
+      expect(mySpyObj).toHaveSpyInteractions()
     });
     `,
     `
@@ -152,8 +161,13 @@ test('maps expect matchers', () => {
       expect(stuff).toBeInstanceOf(Array);
       expect(new Stuff).toBeInstanceOf(Stuff);
 
+      expect([1, 2]).toHaveLength(2);
+
       expect(stuff).not.toBeInstanceOf(Number);
       expect(stuff).not.toBeInstanceOf(Array);
+
+      expect(foo).toBe(Infinity);
+      expect(foo).toBe(-Infinity);
 
       expect(stuff).toMatchObject({foo: 'bar'});
       expect(stuff).toMatchObject({foo: 'bar'});
@@ -169,6 +183,10 @@ test('maps expect matchers', () => {
       expect(stuff).not.toHaveBeenCalled();
       expect(stuff).not.toHaveBeenCalled();
       expect(stuff).toHaveBeenCalledWith('foo', 'bar');
+
+      expect(mySpy.mock.calls).toEqual([['foo', 'bar']]);
+      expect(Math.min(...mySpy.mock.invocationOrder)).toBeLessThan(Math.min(...myOtherSpy.mock.invocationOrder));
+      expect(Object.values(mySpyObj).some(spy => spy.mock?.calls?.length)).toBe(true)
     });
     `
   )

--- a/src/transformers/expect.ts
+++ b/src/transformers/expect.ts
@@ -219,6 +219,83 @@ ${keys}.forEach(e => {
           matcher.name = 'toBe'
           break
         }
+
+        case 'toBePositiveInfinity': {
+          matcherArgs[0] = j.literal(Infinity)
+          matcher.name = 'toBe'
+          break
+        }
+
+        case 'toBeNegativeInfinity': {
+          matcherArgs[0] = j.literal(-Infinity)
+          matcher.name = 'toBe'
+          break
+        }
+
+        case 'toHaveSize': {
+          matcher.name = 'toHaveLength'
+          break
+        }
+
+        case 'toHaveBeenCalledOnceWith': {
+          expectArgs[0] = j.memberExpression(
+            j.memberExpression(expectArgs[0], j.identifier('mock')),
+            j.identifier('calls')
+          )
+          matcher.name = 'toEqual'
+
+          matcherNode.arguments = [j.arrayExpression([j.arrayExpression(matcherArgs)])]
+          break
+        }
+
+        case 'toHaveBeenCalledBefore': {
+          const getMinInvocationOrder = (spy) =>
+            j.callExpression(
+              j.memberExpression(j.identifier('Math'), j.identifier('min')),
+              [
+                j.spreadElement(
+                  j.memberExpression(
+                    j.memberExpression(spy, j.identifier('mock')),
+                    j.identifier('invocationOrder')
+                  )
+                ),
+              ]
+            )
+
+          expectArgs[0] = getMinInvocationOrder(expectArgs[0])
+          matcherArgs[0] = getMinInvocationOrder(matcherArgs[0])
+          matcher.name = 'toBeLessThan'
+          break
+        }
+
+        case 'toHaveSpyInteractions': {
+          expectArgs[0] = j.callExpression(
+            j.memberExpression(
+              j.callExpression(
+                j.memberExpression(j.identifier('Object'), j.identifier('values')),
+                [expectArgs[0]]
+              ),
+              j.identifier('some')
+            ),
+            [
+              j.arrowFunctionExpression(
+                [j.identifier('spy')],
+                j.optionalMemberExpression(
+                  j.optionalMemberExpression(
+                    j.memberExpression(j.identifier('spy'), j.identifier('mock')),
+                    j.identifier('calls'),
+                    false,
+                    true
+                  ),
+                  j.identifier('length')
+                )
+              ),
+            ]
+          )
+          matcherArgs[0] = j.literal(true)
+          matcher.name = 'toBe'
+          break
+        }
       }
 
       balanceMatcherNodeArguments(matcherNode, matcher, path)


### PR DESCRIPTION
added support for toBePositiveInfinity, toBeNegativeInfinity, toHaveSize, toHaveBeenCalledOnceWith, toHaveBeenCalledBefore, toHaveSpyInteractions

credits to @puglyfe