### PR TITLE
fix(jasmine): type transformation for type jasmine.SpyObj if variable declaration and assignment are separate statements

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -427,12 +427,18 @@ describe('types', () => {
       let loggerSpy: jasmine.SpyObj<LoggerService>;
       let unknownSpy: jasmine.SpyObj<unknown>;
       const errorHandlerSpy: jasmine.SpyObj<ErrorHandler> = jasmine.createSpyObj('ErrorHandler', ['handleError']);
+      let translateSpy: jasmine.SpyObj<TranslateService>;
+      translateSpy = jasmine.createSpyObj<TranslateService>(['translate']);
       `,
       `
       let loggerSpy: jest.Mocked<LoggerService>;
       let unknownSpy: jest.Mocked<unknown>;
       const errorHandlerSpy: jest.Mocked<ErrorHandler> = {
             'handleError': jest.fn()
+      };
+      let translateSpy: jest.Mocked<TranslateService>;
+      translateSpy = {
+            'translate': jest.fn()
       };
       `,
       { parser: 'ts' }

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -673,7 +673,7 @@ export default function jasmineGlobals(fileInfo, api, options) {
         )
       }
 
-      if (typeParameters) {
+      if (typeParameters && path.parentPath.node.id) {
         path.parentPath.node.id.typeAnnotation = j.tsTypeAnnotation(
           j.tsTypeReference(
             j.tsQualifiedName(j.identifier('jest'), j.identifier('Mocked')),


### PR DESCRIPTION
Otherwise resulted in 

> TypeError: Cannot set properties of undefined (setting 'typeAnnotation')