### PR TITLE
fix(jasmine): don't transform already transformed nested jasmine spies again

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -384,17 +384,9 @@ describe('createSpyObj', () => {
     `,
       `
     const spyObj = {
-        'a': jest.fn(() => {
-            return 42;
-        }),
-
-        'b': jest.fn(() => {
-            return true;
-        }),
-
-        'c': jest.fn(() => {
-            return of(undefined);
-        })
+        'a': jest.fn(() => 42),
+        'b': jest.fn(() => true),
+        'c': jest.fn(() => of(undefined))
     };
     `
     )
@@ -410,14 +402,8 @@ describe('createSpyObj', () => {
     `,
       `
     const spyObj = {
-        'a': jest.fn(() => {
-            return 42;
-        }),
-
-        'b': jest.fn(() => {
-            return true;
-        }),
-
+        'a': jest.fn(() => 42),
+        'b': jest.fn(() => true),
         'c': null
     };
     `
@@ -466,6 +452,25 @@ describe('createSpyObj', () => {
     };
     `,
       { parser: 'ts' }
+    )
+  })
+
+  test('with methods object that contain nested jasmine Spies', () => {
+    expectTransformation(
+      `
+    const spyObj = jasmine.createSpyObj({
+        a: jasmine.createSpy(),
+        b: jasmine.createSpy().and.returnValue(true),
+        c: of(42)
+    });
+    `,
+      `
+    const spyObj = {
+        'a': jest.fn(),
+        'b': jest.fn(() => true),
+        'c': jest.fn(() => of(42))
+    };
+    `
     )
   })
 })

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -766,20 +766,23 @@ export default function jasmineGlobals(fileInfo, api, options) {
                 )
               )
             )
-          : spyObjMethods.properties.map((arg) =>
-              j.objectProperty(
+          : spyObjMethods.properties.map((arg) => {
+              const alreadyTransformed =
+                arg.value.type === 'CallExpression' &&
+                arg.value.callee.type === 'MemberExpression' &&
+                arg.value.callee.object.name === 'jest' &&
+                arg.value.callee.property.name === 'fn'
+
+              return j.objectProperty(
                 j.literal(arg.key.name),
-                j.callExpression(
-                  j.memberExpression(j.identifier('jest'), j.identifier('fn')),
-                  [
-                    j.arrowFunctionExpression(
-                      [],
-                      j.blockStatement([j.returnStatement(arg.value)])
-                    ),
-                  ]
-                )
+                !alreadyTransformed
+                  ? j.callExpression(
+                      j.memberExpression(j.identifier('jest'), j.identifier('fn')),
+                      [j.arrowFunctionExpression([], arg.value)]
+                    )
+                  : arg.value
               )
-            )
+            })
 
       if (spyObjProperties !== undefined) {
         properties.push(


### PR DESCRIPTION
and use returned expression over a full block with one statement for SpyObj method objects