### PR TITLE
sinon mod improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/update-notifier": "5.1.0",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
-    "ast-types": "0.16.1",
+    "ast-types": "0.14.2",
     "codecov": "3.8.3",
     "eslint": "8.57.0",
     "eslint-config-prettier": "8.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 5.62.0
         version: 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       ast-types:
-        specifier: 0.16.1
-        version: 0.16.1
+        specifier: 0.14.2
+        version: 0.14.2
       codecov:
         specifier: 3.8.3
         version: 3.8.3

--- a/src/transformers/sinon.test.ts
+++ b/src/transformers/sinon.test.ts
@@ -199,6 +199,7 @@ describe.each([
         const stub = sinon.stub(foo, 'bar').withArgs('foo', 1).returns('something')
         sinon.stub(foo, 'bar').withArgs('foo', sinon.match.object).returns('something')
         sinon.stub().withArgs('foo', sinon.match.any).returns('something')
+        sinon.stub().withArgs('boo', sinon.match.any).returnsArg(1)
 `,
         `
         jest.fn().mockImplementation((...args) => {
@@ -236,6 +237,11 @@ describe.each([
                         return 'something';
                 }
         })
+        jest.fn().mockImplementation((...args) => {
+                if (args[0] === 'boo' && args.length >= 2) {
+                        return args[1];
+                }
+        })
 `
       )
     })
@@ -258,7 +264,7 @@ describe.each([
       )
     })
 
-    /* 
+    /*
     apiStub.getCall(0).args[1].data
     apistub.args[1][1]
   */
@@ -402,12 +408,12 @@ describe.each([
       stub.onCall().returns('invalid')
 `,
         `
-      stub.mockImplementation(() => {
+      stub.mockImplementation((...args) => {
             if (stub.mock.calls.length === 0) {
                   return 5;
             }
       })
-      stub.mockImplementation(() => {
+      stub.mockImplementation((...args) => {
             if (stub.mock.calls.length === 1) {
                   return 6;
             }
@@ -441,12 +447,12 @@ describe.each([
       stub.onCall(3).returnsArg(biscuits)
 `,
         `
-      stub.mockImplementation(() => {
+      stub.mockImplementation((...args: any[]) => {
             if (stub.mock.calls.length === 2) {
                   return [8, 9, 10];
             }
       })
-      stub.mockImplementation(() => {
+      stub.mockImplementation((...args: any[]) => {
             if (stub.mock.calls.length === 3) {
                   return biscuits;
             }
@@ -598,6 +604,9 @@ describe.each([
         expect(spy.calledThrice).to.equal(true)
         expect(spy.called).to.equal(true)
 
+        expect(spy.calledOnce).equals(true)
+        expect(spy.called).equals(true)
+
         // .to.be
         expect(Api.get.callCount).to.be(1)
         expect(Api.get.called).to.be(true)
@@ -627,6 +636,9 @@ describe.each([
         expect(spy).toHaveBeenCalledTimes(1)
         expect(spy).toHaveBeenCalledTimes(2)
         expect(spy).toHaveBeenCalledTimes(3)
+        expect(spy).toHaveBeenCalled()
+
+        expect(spy).toHaveBeenCalledTimes(1)
         expect(spy).toHaveBeenCalled()
 
         // .to.be

--- a/src/transformers/sinon.test.ts
+++ b/src/transformers/sinon.test.ts
@@ -713,6 +713,9 @@ describe.each([
         Api.get.restore()
         Api.get.reset()
         sinon.restore()
+        sinon.reset()
+        sinon.resetBehavior()
+        sinon.resetHistory()
         stub.resetBehavior()
         stub.resetHistory()
 `,
@@ -721,6 +724,9 @@ describe.each([
         Api.get.mockRestore()
         Api.get.mockReset()
         jest.restoreAllMocks()
+        jest.resetAllMocks()
+        jest.resetAllMocks()
+        jest.resetAllMocks()
         stub.mockReset()
         stub.mockReset()
 `

--- a/src/transformers/sinon.test.ts
+++ b/src/transformers/sinon.test.ts
@@ -408,12 +408,12 @@ describe.each([
       stub.onCall().returns('invalid')
 `,
         `
-      stub.mockImplementation((...args) => {
+      stub.mockImplementation(() => {
             if (stub.mock.calls.length === 0) {
                   return 5;
             }
       })
-      stub.mockImplementation((...args) => {
+      stub.mockImplementation(() => {
             if (stub.mock.calls.length === 1) {
                   return 6;
             }
@@ -447,12 +447,12 @@ describe.each([
       stub.onCall(3).returnsArg(biscuits)
 `,
         `
-      stub.mockImplementation((...args: any[]) => {
+      stub.mockImplementation(() => {
             if (stub.mock.calls.length === 2) {
                   return [8, 9, 10];
             }
       })
-      stub.mockImplementation((...args: any[]) => {
+      stub.mockImplementation(() => {
             if (stub.mock.calls.length === 3) {
                   return biscuits;
             }

--- a/src/transformers/sinon.test.ts
+++ b/src/transformers/sinon.test.ts
@@ -187,6 +187,58 @@ describe.each([
       )
     })
 
+    it('handles .resolves/.rejects', () => {
+      expectTransformation(
+        `
+        ${sinonImport}
+        sinon.stub().resolves();
+        sinon.stub().resolves(1);
+        sinon.stub().rejects();
+        sinon.stub().rejects(new Error('error msg'));
+  `,
+        `
+        jest.fn().mockResolvedValue();
+        jest.fn().mockResolvedValue(1);
+        jest.fn().mockRejectedValue(new Error());
+        jest.fn().mockRejectedValue(new Error('error msg'));
+  `
+      )
+    })
+
+    it('handles .callsFake', () => {
+      expectTransformation(
+        `
+        ${sinonImport}
+        sinon.stub().callsFake();
+        sinon.stub().callsFake((a, b) => a + b);
+        sinon.stub().callsFake(async () => ({ a: 1 }));
+  `,
+        `
+        jest.fn().mockImplementation();
+        jest.fn().mockImplementation((a, b) => a + b);
+        jest.fn().mockImplementation(async () => ({ a: 1 }));
+  `
+      )
+    })
+
+    it('handles .throws', () => {
+      expectTransformation(
+        `
+        ${sinonImport}
+        sinon.stub().throws();
+        sinon.stub().throws(new Error('error msg'));
+  `,
+        `
+        jest.fn().mockImplementation(() => {
+                throw new Error();
+        });
+        jest.fn().mockImplementation(() => {
+                throw new Error('error msg');
+        });
+  `
+      )
+    })
+
     it('handles .withArgs returns', () => {
       expectTransformation(
         `
@@ -200,6 +252,7 @@ describe.each([
         sinon.stub(foo, 'bar').withArgs('foo', sinon.match.object).returns('something')
         sinon.stub().withArgs('foo', sinon.match.any).returns('something')
         sinon.stub().withArgs('boo', sinon.match.any).returnsArg(1)
+        sinon.stub().withArgs('boo').returns()
 `,
         `
         jest.fn().mockImplementation((...args) => {
@@ -240,6 +293,58 @@ describe.each([
         jest.fn().mockImplementation((...args) => {
                 if (args[0] === 'boo' && args.length >= 2) {
                         return args[1];
+                }
+        })
+        jest.fn().mockImplementation((...args) => {
+                if (args[0] === 'boo') {
+                        return undefined;
+                }
+        })
+`
+      )
+    })
+
+    it('handles .withArgs chained with .resolves/.rejects/.throws/.callsFake', () => {
+      expectTransformation(
+        `
+        ${sinonImport}
+
+        sinon.stub().withArgs('foo').resolves('something')
+        sinon.stub().withArgs('foo', 'bar').rejects()
+        sinon.stub().withArgs('foo', 'bar', 1).rejects(new Error('something'))
+        sinon.stub(Api, 'get').withArgs('foo', 'bar', 1).throws()
+        const stub = sinon.stub(foo, 'bar').withArgs('foo', 1).throws(new Error('something'))
+        sinon.stub(foo, 'bar').withArgs('foo', sinon.match.object).callsFake((_, obj) => obj)
+`,
+        `
+        jest.fn().mockImplementation((...args) => {
+                if (args[0] === 'foo') {
+                        return Promise.resolve('something');
+                }
+        })
+        jest.fn().mockImplementation((...args) => {
+                if (args[0] === 'foo' && args[1] === 'bar') {
+                        return Promise.reject(new Error());
+                }
+        })
+        jest.fn().mockImplementation((...args) => {
+                if (args[0] === 'foo' && args[1] === 'bar' && args[2] === 1) {
+                        return Promise.reject(new Error('something'));
+                }
+        })
+        jest.spyOn(Api, 'get').mockClear().mockImplementation((...args) => {
+                if (args[0] === 'foo' && args[1] === 'bar' && args[2] === 1) {
+                        throw new Error();
+                }
+        })
+        const stub = jest.spyOn(foo, 'bar').mockClear().mockImplementation((...args) => {
+                if (args[0] === 'foo' && args[1] === 1) {
+                        throw new Error('something');
+                }
+        })
+        jest.spyOn(foo, 'bar').mockClear().mockImplementation((...args) => {
+                if (args[0] === 'foo' && typeof args[1] === 'object') {
+                        return ((_, obj) => obj)(...args);
                 }
         })
 `
@@ -392,6 +497,60 @@ describe.each([
         { parser: 'ts' }
       )
     })
+    it('handles .callsArg* after .on*Call/.withArgs', () => {
+      expectTransformation(
+        `
+        ${sinonImport}
+
+        apiStub.onFirstCall().callsArg(0)
+        apiStub.onSecondCall().callsArgOn(1, thisArg)
+        apiStub.onThirdCall().callsArgWith(2, 'a', 'b')
+        apiStub.onCall(2).callsArgOnWith(3, thisArg, 'c', 'd')
+
+        apiStub.withArgs('foo', 'bar').callsArg(0)
+        apiStub.withArgs(sinon.match.any, sinon.match.func).callsArgOn(1, thisArg)
+        apiStub.withArgs(sinon.match.any).callsArgWith(0, 'a', 'b')
+`,
+        `
+        apiStub.mockImplementation((...args) => {
+                if (apiStub.mock.calls.length === 0) {
+                        return args[0]();
+                }
+        })
+        apiStub.mockImplementation((...args) => {
+                if (apiStub.mock.calls.length === 1) {
+                        return args[1].call(thisArg);
+                }
+        })
+        apiStub.mockImplementation((...args) => {
+                if (apiStub.mock.calls.length === 2) {
+                        return args[2]('a', 'b');
+                }
+        })
+        apiStub.mockImplementation((...args) => {
+                if (apiStub.mock.calls.length === 2) {
+                        return args[3].call(thisArg, 'c', 'd');
+                }
+        })
+
+        apiStub.mockImplementation((...args) => {
+                if (args[0] === 'foo' && args[1] === 'bar') {
+                        return args[0]();
+                }
+        })
+        apiStub.mockImplementation((...args) => {
+                if (args.length >= 2 && typeof args[1] === 'function') {
+                        return args[1].call(thisArg);
+                }
+        })
+        apiStub.mockImplementation((...args) => {
+                if (args.length >= 1) {
+                        return args[0]('a', 'b');
+                }
+        })
+`
+      )
+    })
 
     it('handles on*Call', () => {
       expectTransformation(
@@ -470,6 +629,65 @@ describe.each([
       })
 `,
         { parser: 'tsx' }
+      )
+    })
+
+    it('handles on*Call chained with .resolves/.rejects/.throws/.callsFake', () => {
+      expectTransformation(
+        `
+      ${sinonSandboxImport}
+
+      stub.onFirstCall().resolves()
+      stub.onSecondCall().resolves(1)
+
+      stub.onFirstCall().rejects()
+      stub.onSecondCall().rejects(new Error('msg'))
+
+      stub.onThirdCall().throws()
+      stub.onThirdCall().throws(new Error('msg'))
+
+      stub.onCall(1).callsFake(() => 2)
+`,
+        `
+      stub.mockImplementation(() => {
+            if (stub.mock.calls.length === 0) {
+                  return Promise.resolve();
+            }
+      })
+      stub.mockImplementation(() => {
+            if (stub.mock.calls.length === 1) {
+                  return Promise.resolve(1);
+            }
+      })
+
+      stub.mockImplementation(() => {
+            if (stub.mock.calls.length === 0) {
+                  return Promise.reject(new Error());
+            }
+      })
+      stub.mockImplementation(() => {
+            if (stub.mock.calls.length === 1) {
+                  return Promise.reject(new Error('msg'));
+            }
+      })
+
+      stub.mockImplementation(() => {
+            if (stub.mock.calls.length === 2) {
+                  throw new Error();
+            }
+      })
+      stub.mockImplementation(() => {
+            if (stub.mock.calls.length === 2) {
+                  throw new Error('msg');
+            }
+      })
+
+      stub.mockImplementation((...args) => {
+            if (stub.mock.calls.length === 1) {
+                  return (() => 2)(...args);
+            }
+      })
+`
       )
     })
   })

--- a/src/transformers/sinon.ts
+++ b/src/transformers/sinon.ts
@@ -40,14 +40,24 @@ const CHAI_CHAIN_MATCHERS = new Set(
     'toBeFalsy',
   ].map((a) => a.toLowerCase())
 )
-const SINON_CALLED_WITH_METHODS = ['calledWith', 'notCalledWith', 'neverCalledWith']
-const SINON_SPY_METHODS = ['spy', 'stub']
+const SINON_CALLED_WITH_METHODS = [
+  'calledWith',
+  'notCalledWith',
+  'neverCalledWith',
+] as const
+const SINON_SPY_METHODS = ['spy', 'stub'] as const
 const SINON_MOCK_RESETS = {
   reset: 'mockReset',
   resetBehavior: 'mockReset',
   resetHistory: 'mockReset',
   restore: 'mockRestore',
-}
+} as const
+const SINON_GLOBAL_MOCK_RESETS = {
+  reset: 'resetAllMocks',
+  resetBehavior: 'resetAllMocks',
+  resetHistory: 'resetAllMocks',
+  restore: 'restoreAllMocks',
+} as const
 const _sinonMockImpls = [
   'returns',
   'returnsArg',
@@ -701,13 +711,13 @@ function transformMockResets(j, ast) {
         },
         property: {
           type: 'Identifier',
-          name: 'restore',
+          name: (name) => Object.hasOwn(SINON_GLOBAL_MOCK_RESETS, name),
         },
       },
     })
-    .forEach((np) => {
-      np.node.callee.object.name = 'jest'
-      np.node.callee.property.name = 'restoreAllMocks'
+    .forEach(({ node }) => {
+      node.callee.object.name = 'jest'
+      node.callee.property.name = SINON_GLOBAL_MOCK_RESETS[node.callee.property.name]
     })
 
   ast


### PR DESCRIPTION
- support `equals` comparator
- support `resolves`/`rejects`/`throws`/`callsFake` stub behavior methods universally (chained after `on*Call`/`withArgs` or standalone)
- consolidate stub behavior transforms to enable more combinations
- support global resets
- fix `ast-types` dependency version to match `jscodeshift` requirement so that Typescript doesn't complain