### PR TITLE
fix(`jasmine-this`): prevent TS annotations in non-TS files

### DIFF
--- a/src/transformers/jasmine-this.test.ts
+++ b/src/transformers/jasmine-this.test.ts
@@ -517,7 +517,7 @@ describe('foo', () => {
   )
 })
 
-test('adds any type to the test context with typescript (tsx)', () => {
+test('does not add any type to the test context with javascript', () => {
   expectTransformation(
     `
   beforeEach(function () {
@@ -534,6 +534,50 @@ test('adds any type to the test context with typescript (tsx)', () => {
       });
   });
   `,
+    `
+  let testContext;
+
+  beforeEach(() => {
+      testContext = {};
+  });
+
+  beforeEach(() => {
+      testContext.hello = 'hi';
+  });
+
+  afterEach(() => {
+      console.log(testContext.hello);
+  });
+
+  describe('context', () => {
+      it('should work', () => {
+          console.log(testContext.hello);
+      });
+  });
+  `
+  )
+})
+
+test('adds any type to the test context with typescript (tsx)', () => {
+  expectTransformation(
+    {
+      path: 'test.tsx',
+      source: `
+  beforeEach(function () {
+      this.hello = 'hi';
+  });
+
+  afterEach(function () {
+      console.log(this.hello);
+  });
+
+  describe('context', () => {
+      it('should work', function () {
+          console.log(this.hello);
+      });
+  });
+  `,
+    },
     `
   let testContext: any;
 
@@ -561,7 +605,9 @@ test('adds any type to the test context with typescript (tsx)', () => {
 
 test('adds any type to the test context with typescript (ts)', () => {
   expectTransformation(
-    `
+    {
+      path: 'test.ts',
+      source: `
 beforeEach(function () {
     this.hello = 'hi';
 });
@@ -576,6 +622,7 @@ describe('context', () => {
     });
 });
 `,
+    },
     `
 let testContext: any;
 

--- a/src/transformers/jasmine-this.ts
+++ b/src/transformers/jasmine-this.ts
@@ -174,9 +174,10 @@ const jasmineThis: jscodeshift.Transform = (fileInfo, api, options) => {
           j.variableDeclarator(
             j.identifier.from({
               name: contextName,
-              typeAnnotation: ['ts', 'tsx'].includes(options.parser)
-                ? j.typeAnnotation(j.anyTypeAnnotation())
-                : null,
+              typeAnnotation:
+                ['ts', 'tsx'].includes(options.parser) && /\.tsx?$/.test(fileInfo.path)
+                  ? j.typeAnnotation(j.anyTypeAnnotation())
+                  : null,
             }),
             null
           ),

--- a/src/transformers/mocha.test.ts
+++ b/src/transformers/mocha.test.ts
@@ -185,7 +185,7 @@ describe('suite', () => {
   )
 })
 
-test('adds any type to the test context with typescript (tsx)', () => {
+test('does not add any type to the test context with javascript', () => {
   expectTransformation(
     `
 describe('describe', function () {
@@ -203,6 +203,52 @@ describe('describe', function () {
   })
 })
 `,
+    `
+describe('describe', () => {
+  let testContext;
+
+  beforeEach(() => {
+    testContext = {};
+  });
+
+  beforeEach(() => {
+    testContext.hello = 'hi';
+  });
+
+  describe('context', () => {
+    test('test', () => {
+      console.log(testContext.hello);
+    });
+    it('it', () => {
+      console.log(testContext.hello);
+    });
+  })
+})
+`
+  )
+})
+
+test('adds any type to the test context with typescript (tsx)', () => {
+  expectTransformation(
+    {
+      path: 'test.tsx',
+      source: `
+describe('describe', function () {
+  beforeEach(function () {
+    this.hello = 'hi';
+  });
+
+  context('context', () => {
+    test('test', function () {
+      console.log(this.hello);
+    });
+    it('it', function () {
+      console.log(this.hello);
+    });
+  })
+})
+`,
+    },
     `
 describe('describe', () => {
   let testContext: any;
@@ -231,7 +277,9 @@ describe('describe', () => {
 
 test('adds any type to the test context with typescript (ts)', () => {
   expectTransformation(
-    `
+    {
+      path: 'test.ts',
+      source: `
 describe('describe', function () {
   beforeEach(function () {
     this.hello = 'hi';
@@ -247,6 +295,7 @@ describe('describe', function () {
   })
 })
 `,
+    },
     `
 describe('describe', () => {
   let testContext: any;

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -16,10 +16,22 @@ export function api(options): jscodeshift.API {
   }
 }
 
-export function runPlugin(plugin: jscodeshift.Transform, source: string, options = {}) {
-  return plugin({ source, path: 'test.js' }, api(options), options)
+type File = {
+  path: string
+  source: string
+}
+
+export function runPlugin(
+  plugin: jscodeshift.Transform,
+  file: string | File,
+  options = {}
+) {
+  const source = typeof file === 'string' ? file : file.source
+  const path = typeof file === 'string' ? 'test.js' : file.path
+  return plugin({ source, path }, api(options), options)
 }
 
 export function wrapPlugin(plugin: jscodeshift.Transform) {
-  return (source: string, options = {}) => runPlugin(plugin, source, options) || null
+  return (source: string | File, options = {}) =>
+    runPlugin(plugin, source, options) || null
 }


### PR DESCRIPTION
Closes #623 

This adds an extra check to the `jasmine-this` transform (which is also used in the `mocha` transform) to ensure that the source file is actually a TS file rather than just using a TS parser before adding any TS annotations. The tests were previously confirming the existence of this bug, as the filename was hardcoded to `test.js`, but the test asserted that a TS annotation was added.

To test this, I made a backwards-compatible change to the `runPlugin` test util to allow setting the source file name.