### PR TITLE
fix(jasmine): returnValues() should be transformed to a chain of mockReturnValueOnce()

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -150,7 +150,7 @@ test('spyOn', () => {
     jest.spyOn(stuff).mockImplementation(() => 'lol');
     existingSpy.mockImplementation(() => 'lol');
     jest.spyOn(stuff).mockReturnValue('lmao');
-    jest.spyOn(stuff).mockReturnValue(1).mockReturnValue(2).mockReturnValue(3);
+    jest.spyOn(stuff).mockReturnValueOnce(1).mockReturnValueOnce(2).mockReturnValueOnce(3);
     existingSpy.mockReturnValue('lmao');
     jest.spyOn();
     jest.spyOn(stuff).mockImplementation(() => {});

--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -143,6 +143,7 @@ test('spyOn', () => {
     existingSpy.and.callThrough();
     spyOn(something, 'foo').and.stub().and.returnValue(42);
     mySpy.and.stub();
+    anotherSpy.and.returnValues('a', 'b');
     `,
     `
     jest.spyOn().mockReturnValue();
@@ -161,6 +162,7 @@ test('spyOn', () => {
     existingSpy.mockRestore();
     jest.spyOn(something, 'foo').mockReturnValue(42);
     mySpy.mockImplementation(() => {});
+    anotherSpy.mockReturnValueOnce('a').mockReturnValueOnce('b');
     `
   )
 })

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -315,10 +315,7 @@ export default function jasmineGlobals(fileInfo, api, options) {
         }
 
         case 'returnValues': {
-          let mockReturnValuesCall = j.callExpression(
-            j.memberExpression(j.identifier('jest'), j.identifier('spyOn')),
-            path.node.callee.object.object.arguments ?? []
-          )
+          let mockReturnValuesCall = path.node.callee.object.object
 
           for (const argument of path.node.arguments) {
             mockReturnValuesCall = j.callExpression(

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -322,7 +322,10 @@ export default function jasmineGlobals(fileInfo, api, options) {
 
           for (const argument of path.node.arguments) {
             mockReturnValuesCall = j.callExpression(
-              j.memberExpression(mockReturnValuesCall, j.identifier('mockReturnValueOnce')),
+              j.memberExpression(
+                mockReturnValuesCall,
+                j.identifier('mockReturnValueOnce')
+              ),
               [argument]
             )
           }

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -322,7 +322,7 @@ export default function jasmineGlobals(fileInfo, api, options) {
 
           for (const argument of path.node.arguments) {
             mockReturnValuesCall = j.callExpression(
-              j.memberExpression(mockReturnValuesCall, j.identifier('mockReturnValue')),
+              j.memberExpression(mockReturnValuesCall, j.identifier('mockReturnValueOnce')),
               [argument]
             )
           }


### PR DESCRIPTION
fixes #627