### PR TITLE
ci: print git status and diff if there are local changes while trying to publish a release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -12,8 +12,16 @@ if [ "$version" = "$publishedVersion" ]; then
     exit 0
 fi
 
-echo "Deploying version $version."
+if ! git diff --quiet; then
+  echo "Uncommited changes detected:"
+  echo "==========================="
+  git status
+  git diff
+  echo "==========================="
+  exit 1
+fi
 
+echo "Deploying version $version."
 pnpm publish
 
 tag=$version


### PR DESCRIPTION
@skovhus 
just saw that the last release failed and the `main` branch actions are also failing, because of
> ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.

see for example https://github.com/skovhus/jest-codemods/actions/runs/12426316705/job/34694394164

I added some print in case there are local changes, because I'm unsure what the reason is.