### PR TITLE
feat(jasmine-globals): add support for expectAsync with matchers toBeResolvedTo, toBeResolved, toBeRejected, toBeRejectedWith, toBeRejectedWithError

### DIFF
--- a/src/transformers/jasmine-globals.test.ts
+++ b/src/transformers/jasmine-globals.test.ts
@@ -124,6 +124,39 @@ describe('jasmine matchers', () => {
   })
 })
 
+describe('expectAsync matchers', () => {
+  test('toBeResolved', () => {
+    expectTransformation(
+      'await expectAsync(promise).toBeResolved()',
+      'await expect(promise).resolves.toBeUndefined()'
+    )
+  })
+
+  test('toBeResolvedTo', () =>
+    expectTransformation(
+      'await expectAsync(Promise.resolve(42)).toBeResolvedTo(42)',
+      'await expect(Promise.resolve(42)).resolves.toBe(42)'
+    ))
+
+  test('toBeRejected', () =>
+    expectTransformation(
+      'await expectAsync(Promise.reject()).toBeRejected()',
+      'await expect(Promise.reject()).rejects.toBeDefined()'
+    ))
+
+  test('toBeRejectedWith', () =>
+    expectTransformation(
+      'await expectAsync(Promise.reject({error: 42})).toBeRejectedWith({error: 42})',
+      'await expect(Promise.reject({error: 42})).rejects.toEqual({error: 42})'
+    ))
+
+  test('toBeRejectedWithError', () =>
+    expectTransformation(
+      `await expectAsync(rejectingPromise).toBeRejectedWithError(new Error('mayday'))`,
+      `await expect(rejectingPromise).rejects.toThrow(new Error('mayday'))`
+    ))
+})
+
 test('spyOn', () => {
   expectTransformation(
     `

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -1,7 +1,7 @@
 /**
  * Codemod for transforming Jasmine globals into Jest.
  */
-import { match, ObjectProperty } from 'jscodeshift'
+import { ObjectProperty } from 'jscodeshift'
 
 import finale from '../utils/finale'
 import logger from '../utils/logger'

--- a/src/transformers/jasmine-globals.ts
+++ b/src/transformers/jasmine-globals.ts
@@ -150,16 +150,14 @@ export default function jasmineGlobals(fileInfo, api, options) {
     })
     .forEach((path) => {
       const parentNode = path.parent.node
-      const argument = parentNode.arguments[0]
+      const matcher = path.node.property
 
-      const isNegatedMatcher = path.node.property.name === 'not'
-      const matcher = isNegatedMatcher ? path.parent.node.property : path.node.property
-
-      // reset expectAsync with expect
       parentNode.callee.object.callee.name = 'expect'
 
       switch (matcher.name) {
         case 'toBeResolvedTo': {
+          const argument = parentNode.arguments[0]
+
           parentNode.callee.property.name = argument
             ? 'resolves.toBe'
             : 'resolves.toBeUndefined'


### PR DESCRIPTION
add support for [expectAsync](https://jasmine.github.io/api/edge/global.html#expectAsync) with some of its matchers