### PR TITLE
fix(jasmine-this): preserve TypeScript this parameters

### DIFF
--- a/src/transformers/jasmine-this.test.ts
+++ b/src/transformers/jasmine-this.test.ts
@@ -90,6 +90,16 @@ describe('foo', function*() {
   )
 })
 
+test('does not transform functions with a TypeScript this parameter', () => {
+  const source = `
+describe('foo', function(this: { value: string }) {
+  expect(getValue()).toBe('foo');
+});
+`
+
+  expectTransformation({ path: 'test.ts', source }, null, { parser: 'ts' })
+})
+
 test('transforms only test functions context', () => {
   expectTransformation(
     `

--- a/src/transformers/jasmine-this.ts
+++ b/src/transformers/jasmine-this.ts
@@ -246,6 +246,12 @@ const jasmineThis: jscodeshift.Transform = (fileInfo, api, options) => {
         isFunctionExpressionWithinSpecificFunctions(path, allFunctionNames)
       )
       .filter((path) => !path.value.generator)
+      .filter(
+        (path) =>
+          !path.value.params.some(
+            (param) => param.type === 'Identifier' && param.name === 'this'
+          )
+      )
       .replaceWith((path) => {
         const newFn = j.arrowFunctionExpression(
           path.value.params,


### PR DESCRIPTION
## Problem

Arrow functions cannot declare TypeScript's special `this` parameter. The Jasmine context transformer converted every non-generator callback to an arrow function, so `function (this: Context)` could become invalid `this =>` syntax.

## Solution

- Detect callbacks that declare a TypeScript `this` parameter.
- Preserve those callbacks as function expressions.
- Add a TypeScript parser regression test for the invalid transformation.

## Verification

- Focused `jasmine-this` suite passed — 15 tests
- TypeScript build passed
- ESLint passed for the changed transformer and test
- `git diff --check` passed

Fixes #563